### PR TITLE
Simplified OffsetHelper::lastNonWhitespaceOffset()

### DIFF
--- a/lib/Core/Util/OffsetHelper.php
+++ b/lib/Core/Util/OffsetHelper.php
@@ -6,29 +6,6 @@ class OffsetHelper
 {
     public static function lastNonWhitespaceOffset(string $source): int
     {
-        // break the string into an array of single (possibly
-        // multi-byte) characters
-        $chars = preg_split('//u', $source, -1, PREG_SPLIT_NO_EMPTY);
-
-        // if there are no characters, then just return zero
-        if (count($chars) === 0) {
-            return 0;
-        }
-
-        // pop all empty or whitespace-like characters from the
-        // end of the array
-        $index = count($chars) - 1;
-        while($chars) {
-            $char = $chars[$index--];
-            if (0 !== mb_strlen($char) && false === ctype_space($char)) {
-                break;
-            }
-
-            array_pop($chars);
-        }
-
-        // determine the offset based on the multi-byte length of
-        // the remaining elements
-        return mb_strlen(implode('', $chars));
+        return mb_strlen(preg_replace('/[ \t\x0d\n\r\f]+$/u', '', $source));
     }
 }

--- a/tests/Unit/Core/Util/OffsetHelperTest.php
+++ b/tests/Unit/Core/Util/OffsetHelperTest.php
@@ -55,5 +55,10 @@ class OffsetHelperTest extends TestCase
             "foobar<>\t",
             6
         ];
+
+        yield 'long string (about 6MB)' => [
+            str_repeat("foobar", 2**20) . "<>\t",
+            'this is actually unused'
+        ];
     }
 }


### PR DESCRIPTION
- simpler code
- functionally equivalent to the old one (according to `ctype_space` docs)
- much faster on long strings
- probably easier on memory as well (as no character array is allocated)