### PR TITLE
wip : add class_import only if useful for editor

### DIFF
--- a/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
+++ b/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
@@ -60,10 +60,7 @@ class ScfClassCompletor implements TolerantCompletor
 
         $suggestions = [];
         $count = 0;
-        $currentNamespaceDefinition = $node->getNamespaceDefinition();
-        $currentNamespace = (null !== $currentNamespaceDefinition && null !== $currentNamespaceDefinition->name)
-                          ? $currentNamespaceDefinition->name->getText()
-                          : null;
+        $currentNamespace = $this->getCurrentNamespace($node);
         $imports = $node->getImportTablesForCurrentScope();
         /** @var ScfFilePath $file */
         foreach ($files as $file) {
@@ -95,7 +92,8 @@ class ScfClassCompletor implements TolerantCompletor
 
     private function isImportNeeded($candidate, array $imports, ?string $currentNamespace): bool
     {
-        if ($currentNamespace === $candidate->namespace()) {
+        $candidateNamespace = $candidate->namespace();
+        if ($currentNamespace == $candidateNamespace || $candidateNamespace == null) {
             return false;
         }
 
@@ -107,6 +105,15 @@ class ScfClassCompletor implements TolerantCompletor
         }
 
         return true;
+    }
+
+    private function getCurrentNamespace(Node $node): ?string
+    {
+        $currentNamespaceDefinition = $node->getNamespaceDefinition();
+
+        return null !== $currentNamespaceDefinition && null !== $currentNamespaceDefinition->name
+            ? $currentNamespaceDefinition->name->getText()
+            : null;
     }
 
     private function couldComplete(Node $node): bool

--- a/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
+++ b/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
@@ -76,7 +76,7 @@ class ScfClassCompletor implements TolerantCompletor
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'short_description' => $best->__toString(),
-                    'class_import' => $this->isImportNeeded($best, $imports, $currentNamespace) ? $best->__toString() : null,
+                    'class_import' => $this->getClassNameForImport($best, $imports, $currentNamespace),
                 ]
             );
 
@@ -90,21 +90,22 @@ class ScfClassCompletor implements TolerantCompletor
         return Response::fromSuggestions($suggestions->sorted());
     }
 
-    private function isImportNeeded($candidate, array $imports, ?string $currentNamespace): bool
+    private function getClassNameForImport($candidate, array $imports, ?string $currentNamespace): ?string
     {
         $candidateNamespace = $candidate->namespace();
+
         if ($currentNamespace == $candidateNamespace || $candidateNamespace == null) {
-            return false;
+            return null;
         }
 
         /** @var ResolvedName $resolvedName */
         foreach ($imports[0] as $resolvedName) {
             if ($candidate->__toString() === $resolvedName->getFullyQualifiedNameText()) {
-                return false;
+                return null;
             }
         }
 
-        return true;
+        return $candidate->__toString();
     }
 
     private function getCurrentNamespace(Node $node): ?string

--- a/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
+++ b/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
@@ -94,7 +94,7 @@ class ScfClassCompletor implements TolerantCompletor
     {
         $candidateNamespace = $candidate->namespace();
 
-        if ($currentNamespace == $candidateNamespace || $candidateNamespace == null) {
+        if ($currentNamespace === $candidateNamespace || $candidateNamespace === '' ) {
             return null;
         }
 

--- a/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
+++ b/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
@@ -69,16 +69,14 @@ class ScfClassCompletor implements TolerantCompletor
             }
 
             $best = $candidates->best();
-            $options = [
-                'type' => Suggestion::TYPE_CLASS,
-                'short_description' => $best->__toString(),
-            ];
-
-            if (!$this->isAlreadyImported($best->__toString(), $imports)) {
-                $options['class_import'] = $best->__toString();
-            }
-
-            $suggestions[] = Suggestion::createWithOptions($best->name(), $options);
+            $suggestions[] = Suggestion::createWithOptions(
+                $best->name(),
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'short_description' => $best->__toString(),
+                    'class_import' => $this->isAlreadyImported($best->__toString(), $imports) ? null : $best->__toString(),
+                ]
+            );
 
             if (++$count >= $this->limit) {
                 break;

--- a/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
+++ b/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
@@ -59,6 +59,7 @@ class ScfClassCompletor implements TolerantCompletor
 
         $suggestions = [];
         $count = 0;
+        $imports = $node->getImportTablesForCurrentScope();
         /** @var ScfFilePath $file */
         foreach ($files as $file) {
             $candidates = $this->fileToClass->fileToClassCandidates(FilePath::fromString($file->path()));
@@ -73,7 +74,7 @@ class ScfClassCompletor implements TolerantCompletor
                 'short_description' => $best->__toString(),
             ];
 
-            if (!$this->isAlreadyImported($best->__toString(), $node)) {
+            if (!$this->isAlreadyImported($best->__toString(), $imports)) {
                 $options['class_import'] = $best->__toString();
             }
 
@@ -89,9 +90,9 @@ class ScfClassCompletor implements TolerantCompletor
         return Response::fromSuggestions($suggestions->sorted());
     }
 
-    private function isAlreadyImported(string $candidate, Node $node): bool
+    private function isAlreadyImported(string $candidate, array $imports): bool
     {
-        foreach ($node->getImportTablesForCurrentScope()[0] as $resolvedName) {
+        foreach ($imports[0] as $resolvedName) {
             if ($resolvedName->getFullyQualifiedNameText() === $candidate) {
                 return true;
             }

--- a/tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
@@ -27,7 +27,6 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
     public function testComplete(string $source, array $expected)
     {
         $this->assertComplete($source, $expected);
-
     }
 
     public function provideComplete(): Generator
@@ -65,60 +64,20 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
         yield 'extends when class already imported' => [
             '<?php use Test\Name\Alphabet; class Foobar extends <>',
             [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Alphabet',
-                    'short_description' => 'Test\Name\Alphabet',
-                    'class_import' => null,
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Backwards',
-                    'short_description' => 'Test\Name\Backwards',
-                    'class_import' => 'Test\Name\Backwards',
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Clapping',
-                    'short_description' => 'Test\Name\Clapping',
-                    'class_import' => 'Test\Name\Clapping',
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'WithoutNS',
-                    'short_description' => 'WithoutNS',
-                    'class_import' => null,
-                ],
+                ['class_import' => null],
+                ['class_import' => 'Test\Name\Backwards'],
+                ['class_import' => 'Test\Name\Clapping'],
+                ['class_import' => null],
             ],
         ];
 
         yield 'extends when class from same namespace' => [
             '<?php namespace Test\Name; class Foobar extends <>',
             [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Alphabet',
-                    'short_description' => 'Test\Name\Alphabet',
-                    'class_import' => null,
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Backwards',
-                    'short_description' => 'Test\Name\Backwards',
-                    'class_import' => null,
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Clapping',
-                    'short_description' => 'Test\Name\Clapping',
-                    'class_import' => null,
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'WithoutNS',
-                    'short_description' => 'WithoutNS',
-                    'class_import' => null,
-                ],
+                ['class_import' => null],
+                ['class_import' => null],
+                ['class_import' => null],
+                ['class_import' => null],
             ],
         ];
 
@@ -137,36 +96,21 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
         yield 'extends partial' => [
             '<?php class Foobar extends Wi<>',
             [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'WithoutNS',
-                    'short_description' => 'WithoutNS',
-                    'class_import' => null,
-                ],
+                ['class_import' => null],
             ],
         ];
 
         yield 'extends partial with class already imported' => [
             '<?php  use Test\Name\Clapping;  class Foobar extends Cl<>',
             [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Clapping',
-                    'short_description' => 'Test\Name\Clapping',
-                    'class_import' => null,
-                ],
+                ['class_import' => null],
             ],
         ];
 
         yield 'extends partial with class from same namespace' => [
             '<?php  namespace Test\Name;  class Foobar extends Cl<>',
             [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Clapping',
-                    'short_description' => 'Test\Name\Clapping',
-                    'class_import' => null,
-                ],
+                ['class_import' => null],
             ],
         ];
 
@@ -183,26 +127,9 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
         ];
 
         yield 'extends keyword with subsequent code, with class already imported' => [
-            '<?php use Test\Name\Clapping; class Foobar extends Cl<> { }',
+            '<?php use Test\Name\Clapping; class Foobar extends Cl<>',
             [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Clapping',
-                    'short_description' => 'Test\Name\Clapping',
-                    'class_import' => null,
-                ],
-            ],
-        ];
-
-        yield 'extends keyword with subsequent code, with class from same namespace' => [
-            '<?php namespace Test\Name; class Foobar extends Cl<> { }',
-            [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Clapping',
-                    'short_description' => 'Test\Name\Clapping',
-                    'class_import' => null,
-                ],
+                ['class_import' => null],
             ],
         ];
 
@@ -234,64 +161,6 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
             ],
         ];
 
-        yield 'new keyword with already imported class' => [
-            '<?php use Test\Name\Alphabet; new <>',
-            [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Alphabet',
-                    'short_description' => 'Test\Name\Alphabet',
-                    'class_import' => null,
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Backwards',
-                    'short_description' => 'Test\Name\Backwards',
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Clapping',
-                    'short_description' => 'Test\Name\Clapping',
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'WithoutNS',
-                    'short_description' => 'WithoutNS',
-                    'class_import' => null,
-                ],
-            ],
-        ];
-
-        yield 'new keyword with namespace' => [
-            '<?php namespace Test\Name; new <>',
-            [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Alphabet',
-                    'short_description' => 'Test\Name\Alphabet',
-                    'class_import' => null,
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Backwards',
-                    'short_description' => 'Test\Name\Backwards',
-                    'class_import' => null,
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Clapping',
-                    'short_description' => 'Test\Name\Clapping',
-                    'class_import' => null,
-                ],
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'WithoutNS',
-                    'short_description' => 'WithoutNS',
-                    'class_import' => null,
-                ],
-            ],
-        ];
-
         yield 'new keyword with partial' => [
             '<?php new Cla<>',
             [
@@ -300,30 +169,6 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
                     'class_import' => 'Test\Name\Clapping',
-                ],
-            ],
-        ];
-
-        yield 'new keyword with partial with class already imported' => [
-            '<?php use Test\Name\Clapping; new Cla<>',
-            [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Clapping',
-                    'short_description' => 'Test\Name\Clapping',
-                    'class_import' => null,
-                ],
-            ],
-        ];
-
-        yield 'new keyword with partial with class from same namespace' => [
-            '<?php namespace Test\Name; new Cla<>',
-            [
-                [
-                    'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Clapping',
-                    'short_description' => 'Test\Name\Clapping',
-                    'class_import' => null,
                 ],
             ],
         ];

--- a/tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
@@ -39,16 +39,85 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Alphabet',
                     'short_description' => 'Test\Name\Alphabet',
+                    'class_import' => 'Test\Name\Alphabet',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Backwards',
                     'short_description' => 'Test\Name\Backwards',
+                    'class_import' => 'Test\Name\Backwards',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'WithoutNS',
+                    'short_description' => 'WithoutNS',
+                    'class_import' => null,
+                ],
+            ],
+        ];
+
+        yield 'extends when class already imported' => [
+            '<?php use Test\Name\Alphabet; class Foobar extends <>',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Alphabet',
+                    'short_description' => 'Test\Name\Alphabet',
+                    'class_import' => null,
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Backwards',
+                    'short_description' => 'Test\Name\Backwards',
+                    'class_import' => 'Test\Name\Backwards',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Clapping',
+                    'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'WithoutNS',
+                    'short_description' => 'WithoutNS',
+                    'class_import' => null,
+                ],
+            ],
+        ];
+
+        yield 'extends when class from same namespace' => [
+            '<?php namespace Test\Name; class Foobar extends <>',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Alphabet',
+                    'short_description' => 'Test\Name\Alphabet',
+                    'class_import' => null,
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Backwards',
+                    'short_description' => 'Test\Name\Backwards',
+                    'class_import' => null,
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Clapping',
+                    'short_description' => 'Test\Name\Clapping',
+                    'class_import' => null,
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'WithoutNS',
+                    'short_description' => 'WithoutNS',
+                    'class_import' => null,
                 ],
             ],
         ];
@@ -60,11 +129,24 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
 
-        yield 'extends partial with existing import' => [
+        yield 'extends partial' => [
+            '<?php class Foobar extends Wi<>',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'WithoutNS',
+                    'short_description' => 'WithoutNS',
+                    'class_import' => null,
+                ],
+            ],
+        ];
+
+        yield 'extends partial with class already imported' => [
             '<?php  use Test\Name\Clapping;  class Foobar extends Cl<>',
             [
                 [
@@ -76,7 +158,7 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
             ],
         ];
 
-        yield 'extends partial with existing import' => [
+        yield 'extends partial with class from same namespace' => [
             '<?php  namespace Test\Name;  class Foobar extends Cl<>',
             [
                 [
@@ -95,6 +177,31 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
+                ],
+            ],
+        ];
+
+        yield 'extends keyword with subsequent code, with class already imported' => [
+            '<?php use Test\Name\Clapping; class Foobar extends Cl<> { }',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Clapping',
+                    'short_description' => 'Test\Name\Clapping',
+                    'class_import' => null,
+                ],
+            ],
+        ];
+
+        yield 'extends keyword with subsequent code, with class from same namespace' => [
+            '<?php namespace Test\Name; class Foobar extends Cl<> { }',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Clapping',
+                    'short_description' => 'Test\Name\Clapping',
+                    'class_import' => null,
                 ],
             ],
         ];
@@ -106,6 +213,7 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Alphabet',
                     'short_description' => 'Test\Name\Alphabet',
+                    'class_import' => 'Test\Name\Alphabet',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
@@ -116,6 +224,70 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'WithoutNS',
+                    'short_description' => 'WithoutNS',
+                    'class_import' => null,
+                ],
+            ],
+        ];
+
+        yield 'new keyword with already imported class' => [
+            '<?php use Test\Name\Alphabet; new <>',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Alphabet',
+                    'short_description' => 'Test\Name\Alphabet',
+                    'class_import' => null,
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Backwards',
+                    'short_description' => 'Test\Name\Backwards',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Clapping',
+                    'short_description' => 'Test\Name\Clapping',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'WithoutNS',
+                    'short_description' => 'WithoutNS',
+                    'class_import' => null,
+                ],
+            ],
+        ];
+
+        yield 'new keyword with namespace' => [
+            '<?php namespace Test\Name; new <>',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Alphabet',
+                    'short_description' => 'Test\Name\Alphabet',
+                    'class_import' => null,
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Backwards',
+                    'short_description' => 'Test\Name\Backwards',
+                    'class_import' => null,
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Clapping',
+                    'short_description' => 'Test\Name\Clapping',
+                    'class_import' => null,
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'WithoutNS',
+                    'short_description' => 'WithoutNS',
+                    'class_import' => null,
                 ],
             ],
         ];
@@ -127,6 +299,31 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
+                ],
+            ],
+        ];
+
+        yield 'new keyword with partial with class already imported' => [
+            '<?php use Test\Name\Clapping; new Cla<>',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Clapping',
+                    'short_description' => 'Test\Name\Clapping',
+                    'class_import' => null,
+                ],
+            ],
+        ];
+
+        yield 'new keyword with partial with class from same namespace' => [
+            '<?php namespace Test\Name; new Cla<>',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Clapping',
+                    'short_description' => 'Test\Name\Clapping',
+                    'class_import' => null,
                 ],
             ],
         ];
@@ -138,16 +335,25 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Alphabet',
                     'short_description' => 'Test\Name\Alphabet',
+                    'class_import' => 'Test\Name\Alphabet',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Backwards',
                     'short_description' => 'Test\Name\Backwards',
+                    'class_import' => 'Test\Name\Backwards',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'WithoutNS',
+                    'short_description' => 'WithoutNS',
+                    'class_import' => null,
                 ],
             ],
         ];
@@ -159,6 +365,7 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];

--- a/tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
@@ -27,6 +27,7 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
     public function testComplete(string $source, array $expected)
     {
         $this->assertComplete($source, $expected);
+
     }
 
     public function provideComplete(): Generator
@@ -38,22 +39,37 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Alphabet',
                     'short_description' => 'Test\Name\Alphabet',
+                    'class_import' => 'Test\Name\Alphabet',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Backwards',
                     'short_description' => 'Test\Name\Backwards',
+                    'class_import' => 'Test\Name\Backwards',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
 
         yield 'extends partial' => [
             '<?php class Foobar extends Cl<>',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Clapping',
+                    'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
+                ],
+            ],
+        ];
+
+        yield 'extends partial with existing import' => [
+            '<?php  use Test\Name\Clapping  class Foobar extends Cl<>',
             [
                 [
                     'type' => Suggestion::TYPE_CLASS,
@@ -70,6 +86,7 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
@@ -81,16 +98,19 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Alphabet',
                     'short_description' => 'Test\Name\Alphabet',
+                    'class_import' => 'Test\Name\Alphabet',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Backwards',
                     'short_description' => 'Test\Name\Backwards',
+                    'class_import' => 'Test\Name\Backwards',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
@@ -102,6 +122,7 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
@@ -113,16 +134,19 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Alphabet',
                     'short_description' => 'Test\Name\Alphabet',
+                    'class_import' => 'Test\Name\Alphabet',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Backwards',
                     'short_description' => 'Test\Name\Backwards',
+                    'class_import' => 'Test\Name\Backwards',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
@@ -134,6 +158,7 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];

--- a/tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletorTest.php
@@ -39,19 +39,16 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Alphabet',
                     'short_description' => 'Test\Name\Alphabet',
-                    'class_import' => 'Test\Name\Alphabet',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Backwards',
                     'short_description' => 'Test\Name\Backwards',
-                    'class_import' => 'Test\Name\Backwards',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
-                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
@@ -63,18 +60,30 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
-                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
 
         yield 'extends partial with existing import' => [
-            '<?php  use Test\Name\Clapping  class Foobar extends Cl<>',
+            '<?php  use Test\Name\Clapping;  class Foobar extends Cl<>',
             [
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
+                    'class_import' => null,
+                ],
+            ],
+        ];
+
+        yield 'extends partial with existing import' => [
+            '<?php  namespace Test\Name;  class Foobar extends Cl<>',
+            [
+                [
+                    'type' => Suggestion::TYPE_CLASS,
+                    'name' => 'Clapping',
+                    'short_description' => 'Test\Name\Clapping',
+                    'class_import' => null,
                 ],
             ],
         ];
@@ -86,7 +95,6 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
-                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
@@ -98,19 +106,16 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Alphabet',
                     'short_description' => 'Test\Name\Alphabet',
-                    'class_import' => 'Test\Name\Alphabet',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Backwards',
                     'short_description' => 'Test\Name\Backwards',
-                    'class_import' => 'Test\Name\Backwards',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
-                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
@@ -122,7 +127,6 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
-                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
@@ -134,19 +138,16 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Alphabet',
                     'short_description' => 'Test\Name\Alphabet',
-                    'class_import' => 'Test\Name\Alphabet',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Backwards',
                     'short_description' => 'Test\Name\Backwards',
-                    'class_import' => 'Test\Name\Backwards',
                 ],
                 [
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
-                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];
@@ -158,7 +159,6 @@ class ScfClassCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_CLASS,
                     'name' => 'Clapping',
                     'short_description' => 'Test\Name\Clapping',
-                    'class_import' => 'Test\Name\Clapping',
                 ],
             ],
         ];

--- a/tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/files/WithoutNS.php
+++ b/tests/Integration/Bridge/TolerantParser/SourceCodeFilesystem/files/WithoutNS.php
@@ -1,0 +1,5 @@
+<?php
+
+class WithoutNS
+{
+}

--- a/tests/Integration/CompletorTestCase.php
+++ b/tests/Integration/CompletorTestCase.php
@@ -47,6 +47,10 @@ abstract class CompletorTestCase extends TestCase
 
         foreach ($expected as $index => $expectedSuggestion) {
             $this->assertArraySubset($expectedSuggestion, $actual[$index]);
+
+            if (!isset($expectedSuggestion['class_import']) || $expectedSuggestion['class_import'] === null) {
+                $this->assertNull($actual[$index]['class_import']);
+            }
         }
 
         $this->assertCount(count($expected), $actual);

--- a/tests/Integration/CompletorTestCase.php
+++ b/tests/Integration/CompletorTestCase.php
@@ -47,10 +47,6 @@ abstract class CompletorTestCase extends TestCase
 
         foreach ($expected as $index => $expectedSuggestion) {
             $this->assertArraySubset($expectedSuggestion, $actual[$index]);
-
-            if (!isset($expectedSuggestion['class_import']) || $expectedSuggestion['class_import'] === null) {
-                $this->assertNull($actual[$index]['class_import']);
-            }
         }
 
         $this->assertCount(count($expected), $actual);


### PR DESCRIPTION
if candidate is already present in the import table, the editor
shouldn't have to try adding a use statement.

closes #551

@dantleech this is just a start, haven't considered any edge cases yet.