### PR TITLE
Use reflectClassLike instead of reflectClass

### DIFF
--- a/lib/Bridge/TolerantParser/WorseReflection/WorseSignatureHelper.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseSignatureHelper.php
@@ -107,7 +107,7 @@ class WorseSignatureHelper implements SignatureHelper
                 ));
             }
 
-            $reflectionClass = $this->reflector->reflectClass($containerType->className());
+            $reflectionClass = $this->reflector->reflectClassLike($containerType->className());
             $reflectionMethod = $reflectionClass->methods()->get($symbolContext->symbol()->name());
 
             return $this->createSignatureHelp($reflectionMethod, $position);
@@ -120,7 +120,7 @@ class WorseSignatureHelper implements SignatureHelper
     {
         $name = $callable->__toString();
         $functionReflection = $this->reflector->reflectFunction($name);
-        
+
         return $this->createSignatureHelp($functionReflection, $position);
     }
 
@@ -128,27 +128,27 @@ class WorseSignatureHelper implements SignatureHelper
     {
         $signatures = [];
         $parameters = [];
-        
+
         /** @var ReflectionParameter $parameter */
         foreach ($functionReflection->parameters() as $parameter) {
             $formatted = $this->formatter->format($parameter);
             $parameters[] = new ParameterInformation($parameter->name(), $formatted);
         }
-        
+
         $formatted = $this->formatter->format($functionReflection);
         $signatures[] = new SignatureInformation($formatted, $parameters);
-        
+
         return new SignatureHelp($signatures, $position);
     }
 
     private function signatureHelpForScopedPropertyAccess(ScopedPropertyAccessExpression $callable, CallExpression $node, int $position)
     {
         $scopeResolutionQualifier = $callable->scopeResolutionQualifier;
-        
+
         if (!$scopeResolutionQualifier instanceof QualifiedName) {
             throw new CouldNotHelpWithSignature(sprintf('Static calls only supported with qualified names'));
         }
-        
+
         $class = $scopeResolutionQualifier->getResolvedName();
 
         $reflectionClass = $this->reflector->reflectClass((string) $class);
@@ -161,7 +161,7 @@ class WorseSignatureHelper implements SignatureHelper
 
         $memberName = $memberName->getText($node->getFileContents());
         $reflectionMethod = $reflectionClass->methods()->get((string) $memberName);
-        
+
         return $this->createSignatureHelp($reflectionMethod, $position);
     }
 }

--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseSignatureHelperTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseSignatureHelperTest.php
@@ -164,5 +164,20 @@ class WorseSignatureHelperTest extends IntegrationTestCase
                 null
             )
         ];
+
+        yield 'instance from an interface' => [
+            '<?php interface Foo { function hello(string $foo, int $bar): void }; function (Foo $foo) { $foo->hello(<>',
+            new SignatureHelp(
+                [new SignatureInformation(
+                    'pub hello(string $foo, int $bar): void',
+                    [
+                        new ParameterInformation('foo', 'string $foo'),
+                        new ParameterInformation('bar', 'int $bar'),
+                    ]
+                )],
+                0,
+                null
+            )
+        ];
     }
 }


### PR DESCRIPTION
As reported in phpactor/phpactor#752, it was impossible to complete from an interface typehinted property / variable without having a sort of error.

Replacing the call from `reflectClass` to `reflectClassLike` seems to solve this.

Fixes phpactor/phpactor#752