### PR TITLE
[Improvement] Add snipppet to suggestions

### DIFF
--- a/lib/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -37,10 +37,19 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
      */
     private $formatter;
 
-    public function __construct(Reflector $reflector, ObjectFormatter $formatter)
-    {
+    /**
+     * @var ObjectFormatter
+     */
+    private $snippetFormatter;
+
+    public function __construct(
+        Reflector $reflector,
+        ObjectFormatter $formatter,
+        ObjectFormatter $snippetFormatter
+    ) {
         $this->reflector = $reflector;
         $this->formatter = $formatter;
+        $this->snippetFormatter = $snippetFormatter;
     }
 
     public function qualifier(): TolerantQualifier
@@ -131,7 +140,8 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
             yield Suggestion::createWithOptions($method->name(), [
                 'type' => Suggestion::TYPE_METHOD,
                 'short_description' => $this->formatter->format($method),
-                'documentation' => $method->docblock()->formatted()
+                'documentation' => $method->docblock()->formatted(),
+                'snippet' => $this->snippetFormatter->format($method),
             ]);
         }
 

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseFunctionCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseFunctionCompletor.php
@@ -29,10 +29,19 @@ class WorseFunctionCompletor implements TolerantCompletor
      */
     private $formatter;
 
-    public function __construct(Reflector $reflector, ObjectFormatter $formatter)
-    {
+    /**
+     * @var ObjectFormatter
+     */
+    private $snippetFormatter;
+
+    public function __construct(
+        Reflector $reflector,
+        ObjectFormatter $formatter,
+        ObjectFormatter $snippetFormatter
+    ) {
         $this->reflector = $reflector;
         $this->formatter = $formatter;
+        $this->snippetFormatter = $snippetFormatter;
     }
 
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
@@ -60,7 +69,8 @@ class WorseFunctionCompletor implements TolerantCompletor
                 [
                     'type' => Suggestion::TYPE_FUNCTION,
                     'short_description' => $this->formatter->format($functionReflection),
-                    'documentation' => $functionReflection->docblock()->formatted()
+                    'documentation' => $functionReflection->docblock()->formatted(),
+                    'snippet' => $this->snippetFormatter->format($functionReflection),
                 ]
             );
         }
@@ -70,7 +80,7 @@ class WorseFunctionCompletor implements TolerantCompletor
     {
         $functions = get_defined_functions();
         $functions['reflected'] = $reflectedFunctions;
-        
+
         return $this->filterFunctions($functions, $partialName);
     }
 

--- a/lib/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatter.php
+++ b/lib/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatter.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Phpactor\Completion\Bridge\WorseReflection\Formatter;
+
+use Phpactor\Completion\Core\Formatter\Formatter;
+use Phpactor\Completion\Core\Formatter\ObjectFormatter;
+use Phpactor\Completion\Core\Util\Snippet\Placeholder;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionFunction;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
+
+class FunctionLikeSnippetFormatter implements Formatter
+{
+    public function canFormat(object $function): bool
+    {
+        return $function instanceof ReflectionFunction
+            || $function instanceof ReflectionMethod;
+    }
+
+    public function format(ObjectFormatter $formatter, object $function): string
+    {
+        assert(
+            $function instanceof ReflectionFunction
+            || $function instanceof ReflectionMethod
+        );
+
+        $name = $function instanceof ReflectionFunction
+            ? $function->name()->short()
+            : $function->name()
+        ;
+        $parameters = $function->parameters();
+
+        if (0 === $parameters->count()) {
+            return "$name()";
+        }
+
+        $placeholders = [];
+        $position = 0;
+        /** @var ReflectionParameter $parameter */
+        foreach ($parameters as $parameter) {
+            if ($parameter->default()->isDefined()) {
+                continue; // Ignore optional parameters
+            }
+
+            $placeholders[] = Placeholder::escape(++$position, '$'.$parameter->name());
+        }
+
+        return \sprintf(
+            '%s(%s)%s',
+            $name,
+            // If no placeholders then all parameters are optional
+            // But we still want to stop between the parentheses
+            \implode(', ', $placeholders ?: [Placeholder::raw(1)]),
+            Placeholder::raw(0)
+        );
+    }
+}

--- a/lib/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatter.php
+++ b/lib/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatter.php
@@ -31,7 +31,7 @@ class FunctionLikeSnippetFormatter implements Formatter
         $parameters = $functionLike->parameters();
 
         if (0 === $parameters->count()) {
-            return "$name()";
+            return \sprintf('%s()', $name);
         }
 
         $placeholders = [];

--- a/lib/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatter.php
+++ b/lib/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatter.php
@@ -11,24 +11,24 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
 
 class FunctionLikeSnippetFormatter implements Formatter
 {
-    public function canFormat(object $function): bool
+    public function canFormat(object $functionLike): bool
     {
-        return $function instanceof ReflectionFunction
-            || $function instanceof ReflectionMethod;
+        return $functionLike instanceof ReflectionFunction
+            || $functionLike instanceof ReflectionMethod;
     }
 
-    public function format(ObjectFormatter $formatter, object $function): string
+    public function format(ObjectFormatter $formatter, object $functionLike): string
     {
         assert(
-            $function instanceof ReflectionFunction
-            || $function instanceof ReflectionMethod
+            $functionLike instanceof ReflectionFunction
+            || $functionLike instanceof ReflectionMethod
         );
 
-        $name = $function instanceof ReflectionFunction
-            ? $function->name()->short()
-            : $function->name()
+        $name = $functionLike instanceof ReflectionFunction
+            ? $functionLike->name()->short()
+            : $functionLike->name()
         ;
-        $parameters = $function->parameters();
+        $parameters = $functionLike->parameters();
 
         if (0 === $parameters->count()) {
             return "$name()";

--- a/lib/Core/Suggestion.php
+++ b/lib/Core/Suggestion.php
@@ -65,6 +65,11 @@ class Suggestion
      */
     private $documentation;
 
+    /**
+     * @var string|null
+     */
+    private $snippet;
+
     private function __construct(
         string $name,
         ?string $type = null,
@@ -72,7 +77,8 @@ class Suggestion
         ?string $classImport = null,
         ?string $label = null,
         ?string $documentation = null,
-        ?Range $range = null
+        ?Range $range = null,
+        ?string $snippet = null
     ) {
         $this->type = $type;
         $this->name = $name;
@@ -81,6 +87,7 @@ class Suggestion
         $this->label = $label ?: $name;
         $this->range = $range;
         $this->documentation = $documentation;
+        $this->snippet = $snippet;
     }
 
     public static function create(string $name): self
@@ -97,6 +104,7 @@ class Suggestion
             'class_import' => null,
             'label' => null,
             'range' => null,
+            'snippet' => null
         ];
 
         if ($diff = array_diff(array_keys($options), array_keys($defaults))) {
@@ -116,7 +124,8 @@ class Suggestion
             $options['class_import'],
             $options['label'],
             $options['documentation'],
-            $options['range']
+            $options['range'],
+            $options['snippet']
         );
     }
 
@@ -125,6 +134,7 @@ class Suggestion
         return [
             'type' => $this->type(),
             'name' => $this->name(),
+            'snippet' => $this->snippet(),
             'label' => $this->label(),
             'short_description' => $this->shortDescription(),
             'documentation' => $this->documentation(),
@@ -148,6 +158,11 @@ class Suggestion
     public function name(): string
     {
         return $this->name;
+    }
+
+    public function snippet(): ?string
+    {
+        return $this->snippet;
     }
 
     public function shortDescription(): ?string

--- a/lib/Core/Util/Snippet/Placeholder.php
+++ b/lib/Core/Util/Snippet/Placeholder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Phpactor\Completion\Core\Util\Snippet;
+
+final class Placeholder
+{
+    public static function raw(int $position, ?string $default = null): string
+    {
+        return \sprintf('${%d%s}', $position, $default ? ":$default" : null);
+    }
+
+    public static function escape(int $position, ?string $default = null): string
+    {
+        return self::raw($position, self::protect($default));
+    }
+
+    private static function protect(?string $text = null): string
+    {
+        // Important to escape the backslash first!
+        return str_replace(['\\', '$', '}'], ['\\\\', '\$', '\}'], $text);
+    }
+}

--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseBuiltInFunctionCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseBuiltInFunctionCompletorTest.php
@@ -16,7 +16,11 @@ class WorseBuiltInFunctionCompletorTest extends TolerantCompletorTestCase
     {
         $reflector = ReflectorBuilder::create()->addSource($source)->build();
 
-        return new WorseFunctionCompletor($reflector, $this->formatter());
+        return new WorseFunctionCompletor(
+            $reflector,
+            $this->formatter(),
+            $this->snippetFormatter()
+        );
     }
 
     /**
@@ -43,6 +47,7 @@ class WorseBuiltInFunctionCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_FUNCTION,
                     'name' => 'mystrpos',
                     'short_description' => 'mystrpos($haystack, $needle, $offset = 0): int',
+                    'snippet' => 'mystrpos(${1:\$haystack}, ${2:\$needle})${0}',
                 ]
             ]
         ];
@@ -53,6 +58,7 @@ class WorseBuiltInFunctionCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_FUNCTION,
                     'name' => 'barfoo',
                     'short_description' => 'foobar\barfoo(): int',
+                    'snippet' => 'barfoo()',
                 ]
             ]
         ];

--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
@@ -16,7 +16,11 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
     {
         $reflector = ReflectorBuilder::create()->addSource($source)->build();
 
-        return new WorseClassMemberCompletor($reflector, $this->formatter());
+        return new WorseClassMemberCompletor(
+            $reflector,
+            $this->formatter(),
+            $this->snippetFormatter()
+        );
     }
 
     /**
@@ -118,6 +122,7 @@ EOT
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'foo',
                 'short_description' => 'pub foo(string $zzzbar = \'bar\', $def): Barbar',
+                'snippet' => 'foo(${1:\$def})${0}',
             ]
         ]
     ];
@@ -145,6 +150,7 @@ EOT
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'foo',
                 'short_description' => 'pub foo(): Foobar|Barbar',
+                'snippet' => 'foo()',
             ]
         ]
     ];
@@ -194,6 +200,7 @@ EOT
                 'name' => 'foo',
                 'short_description' => 'pub foo(): Foobar|Barbar',
                 'documentation' => "Returns a foobar\n",
+                'snippet' => 'foo()',
             ]
         ]
     ];
@@ -301,6 +308,7 @@ EOT
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'bbb',
                 'short_description' => 'pub bbb()',
+                'snippet' => 'bbb()',
             ]
         ]
     ];
@@ -387,6 +395,7 @@ EOT
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'heyho',
                 'short_description' => 'pub heyho()',
+                'snippet' => 'heyho()',
             ],
         ],
     ];
@@ -409,6 +418,7 @@ EOT
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'method1',
                 'short_description' => 'pub method1()',
+                'snippet' => 'method1()',
             ],
         ],
     ];
@@ -458,6 +468,7 @@ EOT
             [
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'goodbye',
+                'snippet' => 'goodbye()',
             ],
         ]];
 
@@ -481,6 +492,7 @@ EOT
             [
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'goodbye',
+                'snippet' => 'goodbye()',
             ],
         ]];
 
@@ -505,6 +517,7 @@ EOT
             [
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'hello',
+                'snippet' => 'hello()',
             ],
         ]];
 
@@ -525,10 +538,12 @@ EOT
             [
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'goodbye',
+                'snippet' => 'goodbye()',
             ],
             [
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'hello',
+                'snippet' => 'hello()',
             ],
         ]];
 

--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseDeclaredClassCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseDeclaredClassCompletorTest.php
@@ -41,14 +41,14 @@ class WorseDeclaredClassCompletorTest extends TolerantCompletorTestCase
             <<<'EOT'
 <?php
 
-$class = new Exception<>
+$class = new RangeException<>
 EOT
         ,
             [
                 [
                     'type' => Suggestion::TYPE_CLASS,
-                    'name' => 'Exception',
-                    'short_description' => 'Exception(string $message = \'\', int $code = 0, Throwable $previous = NULL)',
+                    'name' => 'RangeException',
+                    'short_description' => 'RangeException(string $message = \'\', int $code = 0, Throwable $previous = NULL)',
                 ]
             ]
         ];

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -36,7 +36,7 @@ class IntegrationTestCase extends TestCase
         ]);
     }
 
-    protected function SnippetFormatter(): ObjectFormatter
+    protected function snippetFormatter(): ObjectFormatter
     {
         return new ObjectFormatter([
             new FunctionLikeSnippetFormatter()

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -5,6 +5,7 @@ namespace Phpactor\Completion\Tests\Integration;
 use Phpactor\Completion\Bridge\WorseReflection\Formatter\ClassFormatter;
 use Phpactor\Completion\Bridge\WorseReflection\Formatter\FunctionFormatter;
 use Phpactor\Completion\Bridge\WorseReflection\Formatter\InterfaceFormatter;
+use Phpactor\Completion\Bridge\WorseReflection\Formatter\FunctionLikeSnippetFormatter;
 use Phpactor\Completion\Bridge\WorseReflection\Formatter\MethodFormatter;
 use Phpactor\Completion\Bridge\WorseReflection\Formatter\TraitFormatter;
 use Phpactor\Completion\Bridge\WorseReflection\Formatter\ParametersFormatter;
@@ -32,6 +33,13 @@ class IntegrationTestCase extends TestCase
             new ClassFormatter(),
             new InterfaceFormatter(),
             new TraitFormatter(),
+        ]);
+    }
+
+    protected function SnippetFormatter(): ObjectFormatter
+    {
+        return new ObjectFormatter([
+            new FunctionLikeSnippetFormatter()
         ]);
     }
 }

--- a/tests/Unit/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatterTest.php
+++ b/tests/Unit/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatterTest.php
@@ -22,7 +22,7 @@ final class FunctionLikeSnippetFormatterTest extends TestCase
     /**
      * @dataProvider provideReflectionToFormat
      */
-    public function testFormat(ReflectionFunctionLike $reflection, $expected): void
+    public function testFormat(ReflectionFunctionLike $reflection, string $expected): void
     {
         $this->assertEquals(
             $expected,

--- a/tests/Unit/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatterTest.php
+++ b/tests/Unit/Bridge/WorseReflection/Formatter/FunctionLikeSnippetFormatterTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Phpactor\Completion\Tests\Unit\Bridge\WorseReflection\Formatter;
+
+use ArrayIterator;
+use Phpactor\Completion\Bridge\WorseReflection\Formatter\FunctionLikeSnippetFormatter;
+use Phpactor\Completion\Core\Formatter\ObjectFormatter;
+use Phpactor\Completion\Tests\TestCase;
+use Phpactor\WorseReflection\Core\DefaultValue;
+use Phpactor\WorseReflection\Core\Name;
+use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionParameterCollection;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionFunction;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionFunctionLike;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionMethod;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionParameter;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+final class FunctionLikeSnippetFormatterTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @dataProvider provideReflectionToFormat
+     */
+    public function testFormat(ReflectionFunctionLike $reflection, $expected): void
+    {
+        $this->assertEquals(
+            $expected,
+            $this->format($reflection)
+        );
+    }
+
+    public function provideReflectionToFormat(): iterable
+    {
+        yield 'Function without parameters' => [
+            $this->reflectFunction('func', []),
+            'func()',
+        ];
+
+        yield 'Function with mandatory parameters' => [
+            $this->reflectFunction('func', [
+                $this->parameter('test'),
+                $this->parameter('i'),
+            ]),
+            'func(${1:\$test}, ${2:\$i})${0}'
+        ];
+
+        yield 'Function with mandatory and optional parameters' => [
+            $this->reflectFunction('func', [
+                $this->parameter('test'),
+                $this->parameter('i', true),
+            ]),
+            'func(${1:\$test})${0}'
+        ];
+
+        yield 'Function with only optional parameters' => [
+            $this->reflectFunction('func', [
+                $this->parameter('test', true),
+                $this->parameter('i', true),
+            ]),
+            'func(${1})${0}'
+        ];
+
+        yield 'Method without parameters' => [
+            $this->reflectMethod('method', []),
+            'method()'
+        ];
+
+        yield 'Method with mandatory parameters' => [
+            $this->reflectFunction('method', [
+                $this->parameter('test'),
+                $this->parameter('i'),
+            ]),
+            'method(${1:\$test}, ${2:\$i})${0}'
+        ];
+
+        yield 'Method with mandatory and optional parameters' => [
+            $this->reflectFunction('method', [
+                $this->parameter('test'),
+                $this->parameter('i', true),
+            ]),
+            'method(${1:\$test})${0}'
+        ];
+
+        yield 'Method with only optional parameters' => [
+            $this->reflectFunction('method', [
+                $this->parameter('test', true),
+                $this->parameter('i', true),
+            ]),
+            'method(${1})${0}'
+        ];
+    }
+
+    private function format(ReflectionFunctionLike $reflection): string
+    {
+        return (new FunctionLikeSnippetFormatter())
+            ->format(new ObjectFormatter([]), $reflection)
+        ;
+    }
+
+    private function parameter(string $name, bool $hasDefaultValue = false)
+    {
+        $defaultValue = $hasDefaultValue
+            ? DefaultValue::fromValue('test')
+            : DefaultValue::undefined()
+        ;
+
+        $parameter = $this->prophesize(ReflectionParameter::class);
+        $parameter->name()->willReturn($name);
+        $parameter->default()->willReturn($defaultValue);
+
+        return $parameter->reveal();
+    }
+
+    private function reflectFunctionLike(
+        string $reflectionFunctionLikeFqcn,
+        string $name,
+        array $parameters = []
+    ): ReflectionFunctionLike {
+        $parameterCollection = $this->prophesize(ReflectionParameterCollection::class);
+        $parameterCollection->getIterator()->willReturn(new ArrayIterator($parameters));
+        $parameterCollection->count()->willReturn(\count($parameters));
+
+        $function = $this->prophesize($reflectionFunctionLikeFqcn);
+        $function->name()->willReturn(Name::fromString($name));
+        $function->parameters()->willReturn($parameterCollection->reveal());
+
+        return $function->reveal();
+    }
+
+    private function reflectFunction(string $name, array $parameters = [])
+    {
+        return $this->reflectFunctionLike(ReflectionFunction::class, $name, $parameters);
+    }
+
+    private function reflectMethod(string $name, array $parameters = [])
+    {
+        return $this->reflectFunctionLike(ReflectionMethod::class, $name, $parameters);
+    }
+}

--- a/tests/Unit/Core/SuggestionTest.php
+++ b/tests/Unit/Core/SuggestionTest.php
@@ -48,7 +48,8 @@ class SuggestionTest extends TestCase
             'class_import' => 'Namespace\\Foobar',
             'documentation' => 'foo',
             'label' => 'hallo',
-            'range' => Range::fromStartAndEnd(1, 2)
+            'range' => Range::fromStartAndEnd(1, 2),
+            'snippet' => 'FooBar(${1:\$label})$0', // For test purposes
         ]);
 
         $this->assertEquals([
@@ -60,6 +61,7 @@ class SuggestionTest extends TestCase
             'label' => 'hallo',
             'range' => [1, 2],
             'info' => 'Foobar',
+            'snippet' => 'FooBar(${1:\$label})$0'
         ], $suggestion->toArray());
     }
 }

--- a/tests/Unit/Core/SuggestionTest.php
+++ b/tests/Unit/Core/SuggestionTest.php
@@ -49,7 +49,7 @@ class SuggestionTest extends TestCase
             'documentation' => 'foo',
             'label' => 'hallo',
             'range' => Range::fromStartAndEnd(1, 2),
-            'snippet' => 'FooBar(${1:\$label})$0', // For test purposes
+            'snippet' => null,
         ]);
 
         $this->assertEquals([
@@ -61,7 +61,7 @@ class SuggestionTest extends TestCase
             'label' => 'hallo',
             'range' => [1, 2],
             'info' => 'Foobar',
-            'snippet' => 'FooBar(${1:\$label})$0'
+            'snippet' => null,
         ], $suggestion->toArray());
     }
 }

--- a/tests/Unit/Core/Util/Snippet/PlaceholderTest.php
+++ b/tests/Unit/Core/Util/Snippet/PlaceholderTest.php
@@ -10,7 +10,7 @@ final class PlaceholderTest extends TestCase
     /**
      * @dataProvider providePlaceholders
      */
-    public function testRaw(int $position, ?string $text, string $expected): void
+    public function testRaw(int $position, ?string $text): void
     {
         $this->assertEquals(
             \sprintf('${%d%s}', $position, $text ? ":$text" : null),
@@ -31,10 +31,10 @@ final class PlaceholderTest extends TestCase
 
     public function providePlaceholders(): iterable
     {
-        yield 'No text' => [1, null, '${1}'];
-        yield 'With text' => [3, 'default', '${3:default}'];
-        yield 'With a $' => [3, '$default', '${3:\$default}'];
-        yield 'With a \\' => [3, '\default', '${3:\\\default}'];
-        yield 'With a }' => [3, 'default}', '${3:default\}}'];
+        yield 'no text' => [1, null, '${1}'];
+        yield 'with text' => [3, 'default', '${3:default}'];
+        yield 'with a $' => [3, '$default', '${3:\$default}'];
+        yield 'with a \\' => [3, '\default', '${3:\\\default}'];
+        yield 'with a }' => [3, 'default}', '${3:default\}}'];
     }
 }

--- a/tests/Unit/Core/Util/Snippet/PlaceholderTest.php
+++ b/tests/Unit/Core/Util/Snippet/PlaceholderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Phpactor\Completion\Tests\Unit\Core\Util\Snippet;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Completion\Core\Util\Snippet\Placeholder;
+
+final class PlaceholderTest extends TestCase
+{
+    /**
+     * @dataProvider providePlaceholders
+     */
+    public function testRaw(int $position, ?string $text, string $expected): void
+    {
+        $this->assertEquals(
+            \sprintf('${%d%s}', $position, $text ? ":$text" : null),
+            Placeholder::raw($position, $text)
+        );
+    }
+
+    /**
+     * @dataProvider providePlaceholders
+     */
+    public function testEscape(int $position, ?string $text, string $expected): void
+    {
+        $this->assertEquals(
+            $expected,
+            Placeholder::escape($position, $text)
+        );
+    }
+
+    public function providePlaceholders(): iterable
+    {
+        yield 'No text' => [1, null, '${1}'];
+        yield 'With text' => [3, 'default', '${3:default}'];
+        yield 'With a $' => [3, '$default', '${3:\$default}'];
+        yield 'With a \\' => [3, '\default', '${3:\\\default}'];
+        yield 'With a }' => [3, 'default}', '${3:default\}}'];
+    }
+}


### PR DESCRIPTION
This add a `snippet` information to the `Suggestion` class.
So that we can handle them at this level instead of in the completion handlers.