### PR TITLE
fix: completors return if they are complete

### DIFF
--- a/lib/Bridge/TolerantParser/ChainTolerantCompletor.php
+++ b/lib/Bridge/TolerantParser/ChainTolerantCompletor.php
@@ -40,6 +40,8 @@ class ChainTolerantCompletor implements Completor
             strlen($truncatedSource)
         );
 
+        $isComplete = true;
+
         foreach ($this->tolerantCompletors as $tolerantCompletor) {
             $completionNode = $node;
 
@@ -51,10 +53,14 @@ class ChainTolerantCompletor implements Completor
                 continue;
             }
 
-            foreach ($tolerantCompletor->complete($completionNode, $source, $byteOffset) as $suggestion) {
-                yield $suggestion;
-            }
+            $suggestions = $tolerantCompletor->complete($completionNode, $source, $byteOffset);
+
+            yield from $suggestions;
+
+            $isComplete = $isComplete && $suggestions->getReturn();
         }
+
+        return $isComplete;
     }
 
     private function truncateSource(string $source, int $byteOffset): string

--- a/lib/Bridge/TolerantParser/LimitingCompletor.php
+++ b/lib/Bridge/TolerantParser/LimitingCompletor.php
@@ -34,13 +34,16 @@ class LimitingCompletor implements TolerantCompletor, TolerantQualifiable
         /** @var TolerantCompletor $completor */
         $completor = $this->completor;
         $count = 0;
-        foreach ($completor->complete($node, $source, $offset) as $suggestion) {
+        $suggestions = $completor->complete($node, $source, $offset);
+        foreach ($suggestions as $suggestion) {
             yield $suggestion;
 
             if (++$count === $this->limit) {
-                break;
+                return false;
             }
         }
+
+        return $suggestions->getReturn();
     }
 
     public function qualifier(): TolerantQualifier

--- a/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
+++ b/lib/Bridge/TolerantParser/SourceCodeFilesystem/ScfClassCompletor.php
@@ -84,6 +84,8 @@ class ScfClassCompletor implements TolerantCompletor, TolerantQualifiable
                 );
             }
         }
+
+        return true;
     }
 
     private function getClassNameForImport(ClassName $candidate, array $imports, string $currentNamespace = null): ?string

--- a/lib/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/AbstractParameterCompletor.php
@@ -52,13 +52,13 @@ abstract class AbstractParameterCompletor
     {
         // function has no parameters, return empty handed
         if ($functionLikeReflection->parameters()->count() === 0) {
-            return;
+            return true;
         }
 
         $paramIndex = $this->paramIndex($callableExpression);
 
         if ($this->numberOfArgumentsExceedParameterArity($functionLikeReflection, $paramIndex)) {
-            return;
+            return true;
         }
 
         $parameter = $this->reflectedParameter($functionLikeReflection, $paramIndex);
@@ -85,6 +85,8 @@ abstract class AbstractParameterCompletor
                 ]
             );
         }
+
+        return true;
     }
 
     private function paramIndex(Node $node): int

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseClassAliasCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseClassAliasCompletor.php
@@ -58,6 +58,8 @@ class WorseClassAliasCompletor implements TolerantCompletor, TolerantQualifiable
                 ]
             );
         }
+
+        return true;
     }
 
     public function qualifier(): TolerantQualifier

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -77,7 +77,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
         }
 
         if (!$memberName instanceof Token) {
-            return;
+            return true;
         }
 
         $partialMatch = (string) $memberName->getText($node->getFileContents());
@@ -97,6 +97,8 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
                 yield $suggestion;
             }
         }
+
+        return true;
     }
 
     private function populateSuggestions(SymbolContext $symbolContext, Type $type, bool $static): Generator

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseConstantCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseConstantCompletor.php
@@ -16,7 +16,7 @@ class WorseConstantCompletor implements TolerantCompletor
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         if (!$node instanceof QualifiedName) {
-            return;
+            return true;
         }
 
         $definedConstants = get_defined_constants();
@@ -35,5 +35,7 @@ class WorseConstantCompletor implements TolerantCompletor
                 );
             }
         }
+
+        return true;
     }
 }

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseDeclaredClassCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseDeclaredClassCompletor.php
@@ -61,6 +61,8 @@ class WorseDeclaredClassCompletor implements TolerantCompletor, TolerantQualifia
                 ]
             );
         }
+
+        return true;
     }
 
     public function qualifier(): TolerantQualifier

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseFunctionCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseFunctionCompletor.php
@@ -47,15 +47,15 @@ class WorseFunctionCompletor implements TolerantCompletor
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         if (false === $node instanceof QualifiedName) {
-            return;
+            return true;
         }
 
         if ($node->parent instanceof MethodDeclaration) {
-            return;
+            return true;
         }
 
         if ($node->parent instanceof Parameter) {
-            return;
+            return true;
         }
 
         $functionNames = $this->reflectedFunctions($source);
@@ -74,6 +74,8 @@ class WorseFunctionCompletor implements TolerantCompletor
                 ]
             );
         }
+
+        return true;
     }
 
     private function definedNamesFor(array $reflectedFunctions, string $partialName): Generator

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseLocalVariableCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseLocalVariableCompletor.php
@@ -43,7 +43,7 @@ class WorseLocalVariableCompletor implements TolerantCompletor
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
         if (false === $this->couldComplete($node, $source, $offset)) {
-            return;
+            return true;
         }
 
         foreach ($this->variableCompletionHelper->variableCompletions($node, $source, $offset) as $local) {
@@ -55,6 +55,8 @@ class WorseLocalVariableCompletor implements TolerantCompletor
                 ]
             );
         }
+
+        return true;
     }
 
     private function couldComplete(Node $node = null, TextDocument $source, ByteOffset $offset): bool

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseParameterCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseParameterCompletor.php
@@ -38,13 +38,13 @@ class WorseParameterCompletor extends AbstractParameterCompletor implements Tole
         }
 
         if (!$node instanceof Variable && !$node instanceof CallExpression) {
-            return;
+            return true;
         }
 
         $callExpression = $node instanceof CallExpression ? $node : $node->getFirstAncestor(CallExpression::class);
 
         if (!$callExpression) {
-            return;
+            return true;
         }
 
         assert($callExpression instanceof CallExpression);
@@ -54,22 +54,23 @@ class WorseParameterCompletor extends AbstractParameterCompletor implements Tole
 
         // no variables available for completion, return empty handed
         if (empty($variables)) {
-            return;
+            return true;
         }
 
         try {
             $reflectionFunctionLike = $this->reflectFunctionLike($source, $callableExpression);
         } catch (NotFound $exception) {
-            return;
+            return true;
         }
 
         if (null === $reflectionFunctionLike) {
-            return;
+            return true;
         }
 
-        foreach ($this->populateResponse($callableExpression, $reflectionFunctionLike, $variables) as $suggestion) {
-            yield $suggestion;
-        }
+        $suggestions = $this->populateResponse($callableExpression, $reflectionFunctionLike, $variables);
+        yield from $suggestions;
+
+        return $suggestions->getReturn();
     }
 
     private function paramIndex(Node $node): int

--- a/lib/Core/ChainCompletor.php
+++ b/lib/Core/ChainCompletor.php
@@ -23,10 +23,16 @@ class ChainCompletor implements Completor
 
     public function complete(TextDocument $source, ByteOffset $offset): Generator
     {
+        $isComplete = true;
+
         foreach ($this->completors as $completor) {
-            foreach ($completor->complete($source, $offset) as $suggestion) {
-                yield $suggestion;
-            }
+            $suggestions = $completor->complete($source, $offset);
+
+            yield from $suggestions;
+
+            $isComplete = $isComplete && $suggestions->getReturn();
         }
+
+        return $isComplete;
     }
 }

--- a/lib/Core/Completor/ArrayCompletor.php
+++ b/lib/Core/Completor/ArrayCompletor.php
@@ -27,8 +27,8 @@ class ArrayCompletor implements Completor
      */
     public function complete(TextDocument $source, ByteOffset $byteOffset): Generator
     {
-        foreach ($this->suggestions as $suggestion) {
-            yield $suggestion;
-        }
+        yield from $this->suggestions;
+
+        return true;
     }
 }

--- a/lib/Core/Completor/DedupeCompletor.php
+++ b/lib/Core/Completor/DedupeCompletor.php
@@ -31,7 +31,8 @@ class DedupeCompletor implements Completor
     public function complete(TextDocument $source, ByteOffset $byteOffset): Generator
     {
         $seen = [];
-        foreach ($this->innerCompletor->complete($source, $byteOffset) as $suggestion) {
+        $suggestions = $this->innerCompletor->complete($source, $byteOffset);
+        foreach ($suggestions as $suggestion) {
             $key = $suggestion->name();
 
             if ($this->matchShortDescription) {
@@ -46,5 +47,7 @@ class DedupeCompletor implements Completor
 
             yield $suggestion;
         }
+
+        return $suggestions->getReturn();
     }
 }

--- a/lib/Core/Completor/LimitingCompletor.php
+++ b/lib/Core/Completor/LimitingCompletor.php
@@ -20,7 +20,6 @@ class LimitingCompletor implements Completor
      */
     private $limit;
 
-
     public function __construct(Completor $innerCompletor, int $limit = 32)
     {
         $this->innerCompletor = $innerCompletor;
@@ -40,11 +39,14 @@ class LimitingCompletor implements Completor
     public function complete(TextDocument $source, ByteOffset $byteOffset): Generator
     {
         $count = 0;
-        foreach ($this->innerCompletor->complete($source, $byteOffset) as $suggestion) {
+        $suggestions = $this->innerCompletor->complete($source, $byteOffset);
+        foreach ($suggestions as $suggestion) {
             if ($count++ >= $this->limit) {
-                break;
+                return false;
             }
             yield $suggestion;
         }
+
+        return $suggestions->getReturn();
     }
 }

--- a/tests/Unit/Bridge/TolerantParser/ChainTolerantCompletorTest.php
+++ b/tests/Unit/Bridge/TolerantParser/ChainTolerantCompletorTest.php
@@ -60,6 +60,7 @@ class ChainTolerantCompletorTest extends TestCase
             ByteOffset::fromInt(1)
         );
         $this->assertCount(0, $suggestions);
+        $this->assertTrue($suggestions->getReturn());
     }
 
     public function testCallsCompletors()
@@ -74,6 +75,7 @@ class ChainTolerantCompletorTest extends TestCase
             ByteOffset::fromInt(1)
         )->will(function () {
             yield Suggestion::create('foo');
+            return false;
         });
 
         $suggestions = $completor->complete(
@@ -81,6 +83,7 @@ class ChainTolerantCompletorTest extends TestCase
             ByteOffset::fromInt(1)
         );
         $this->assertCount(1, $suggestions);
+        $this->assertFalse($suggestions->getReturn());
     }
 
     public function testPassesCorrectByteOffsetToParser()
@@ -143,6 +146,7 @@ EOT
             ByteOffset::fromInt(1)
         )->will(function () {
             yield Suggestion::create('foo');
+            return true;
         });
         $this->qualifiableCompletor2->complete(Argument::cetera())->shouldNotBeCalled();
 
@@ -151,6 +155,7 @@ EOT
             ByteOffset::fromInt(1)
         );
         $this->assertCount(1, $suggestions);
+        $this->assertTrue($suggestions->getReturn());
     }
 
     private function create(array $completors): ChainTolerantCompletor

--- a/tests/Unit/Core/Completor/DedupeCompletorTest.php
+++ b/tests/Unit/Core/Completor/DedupeCompletorTest.php
@@ -22,10 +22,12 @@ class DedupeCompletorTest extends TestCase
             Suggestion::create('foobar'),
         ]);
         $dedupe = new DedupeCompletor($inner);
+        $suggestions = $dedupe->complete($source, $offset);
         self::assertEquals([
             Suggestion::create('foobar'),
             Suggestion::create('barfoo'),
-        ], iterator_to_array($dedupe->complete($source, $offset)));
+        ], iterator_to_array($suggestions));
+        $this->assertTrue($suggestions->getReturn());
     }
 
     public function testDeduplicatesWithShortDescription()
@@ -44,6 +46,7 @@ class DedupeCompletorTest extends TestCase
             ]),
         ]);
         $dedupe = new DedupeCompletor($inner, true);
+        $suggestions = $dedupe->complete($source, $offset);
         self::assertEquals([
             Suggestion::create('foobar'),
             Suggestion::createWithOptions('barfoo', [
@@ -52,6 +55,7 @@ class DedupeCompletorTest extends TestCase
             Suggestion::createWithOptions('barfoo', [
                 'short_description' => 'bosh',
             ]),
-        ], iterator_to_array($dedupe->complete($source, $offset)));
+        ], iterator_to_array($suggestions));
+        $this->assertTrue($suggestions->getReturn());
     }
 }

--- a/tests/Unit/Core/Completor/LimitingCompletorTest.php
+++ b/tests/Unit/Core/Completor/LimitingCompletorTest.php
@@ -24,9 +24,29 @@ class LimitingCompletorTest extends TestCase
             Suggestion::create('foobar'),
         ]);
         $dedupe = new LimitingCompletor($inner, 2);
+        $suggestions = $dedupe->complete($source, $offset);
         self::assertEquals([
             Suggestion::create('foobar'),
             Suggestion::create('foobar'),
-        ], iterator_to_array($dedupe->complete($source, $offset)));
+        ], iterator_to_array($suggestions));
+        $this->assertFalse($suggestions->getReturn());
+    }
+
+    public function testDoesNotLimitsResults()
+    {
+        $source = TextDocumentBuilder::create('foobar')->build();
+        $offset = ByteOffset::fromInt(10);
+
+        $inner = new ArrayCompletor([
+            Suggestion::create('foobar'),
+            Suggestion::create('foobar'),
+        ]);
+        $dedupe = new LimitingCompletor($inner, 2);
+        $suggestions = $dedupe->complete($source, $offset);
+        self::assertEquals([
+            Suggestion::create('foobar'),
+            Suggestion::create('foobar'),
+        ], iterator_to_array($suggestions));
+        $this->assertTrue($suggestions->getReturn());
     }
 }


### PR DESCRIPTION
The goal is to be able to know if a completor returned all its results or not.
We talked about it in slack, changing all completors return type seemed  a bit much and looking at the PHP `Generator` class I discovered the `getReturn()` method.

At the end I decided to leverage it in order to minimize the changes required to achieve the initial goal.