### PR TITLE
fix: signature helper

### DIFF
--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseSignatureHelperTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseSignatureHelperTest.php
@@ -106,6 +106,120 @@ class WorseSignatureHelperTest extends IntegrationTestCase
             )
         ];
 
+        yield 'function with parameters, 2nd active and already filled' => [
+            '<?php function hello(string $foo, int $bar) {}; hello("hello", $test<>',
+            new SignatureHelp(
+                [new SignatureInformation(
+                    'hello(string $foo, int $bar)',
+                    [
+                        new ParameterInformation('foo', 'string $foo'),
+                        new ParameterInformation('bar', 'int $bar'),
+                    ]
+                )],
+                0,
+                1
+            )
+        ];
+
+        yield 'function with parameters, 2nd active within other nodes' => [
+            '<?php function hello(string $foo, int $bar) {}; hello("hello", [1, [<>]]',
+            new SignatureHelp(
+                [new SignatureInformation(
+                    'hello(string $foo, int $bar)',
+                    [
+                        new ParameterInformation('foo', 'string $foo'),
+                        new ParameterInformation('bar', 'int $bar'),
+                    ]
+                )],
+                0,
+                1
+            )
+        ];
+
+        yield 'function with parameters, 2nd active on multiple lines' => [
+            <<<'EOT'
+<?php
+function hello(string $foo, int $bar) {};
+hello(
+    "hello",
+    <>
+);
+EOT,
+            new SignatureHelp(
+                [new SignatureInformation(
+                    'hello(string $foo, int $bar)',
+                    [
+                        new ParameterInformation('foo', 'string $foo'),
+                        new ParameterInformation('bar', 'int $bar'),
+                    ]
+                )],
+                0,
+                1
+            )
+        ];
+
+        yield 'nested function with parameters, 2nd active' => [
+            <<<'EOT'
+<?php
+function hello(string $foo, int $bar) {};
+function goodbye(string $good, int $by) {};
+hello(goodbye(
+    "hello",
+    <>
+));
+EOT,
+            new SignatureHelp(
+                [new SignatureInformation(
+                    'goodbye(string $good, int $by)',
+                    [
+                        new ParameterInformation('good', 'string $good'),
+                        new ParameterInformation('by', 'int $by'),
+                    ]
+                )],
+                0,
+                1
+            )
+        ];
+
+        yield 'nested function on the second function, 2nd arg of 1st call active' => [
+            <<<'EOT'
+<?php
+function hello(string $foo, int $bar) {};
+function goodbye(string $good, int $by) {};
+hello(
+    "hello",
+    goo<>dbye("good", "by")
+);
+EOT,
+            new SignatureHelp(
+                [new SignatureInformation(
+                    'hello(string $foo, int $bar)',
+                    [
+                        new ParameterInformation('foo', 'string $foo'),
+                        new ParameterInformation('bar', 'int $bar'),
+                    ]
+                )],
+                0,
+                1
+            )
+        ];
+
+        yield 'function with parameters, 1st contains comma and 2nd active' => [
+            '<?php function hello(string $foo, int $bar, bool $foobar) {}; hello("hello, ",<>',
+            new SignatureHelp(
+                [new SignatureInformation(
+                    'hello(string $foo, int $bar, bool $foobar)',
+                    [
+                        new ParameterInformation('foo', 'string $foo'),
+                        new ParameterInformation('bar', 'int $bar'),
+                        new ParameterInformation('foobar', 'bool $foobar'),
+                    ]
+                )],
+                0,
+                1
+            )
+        ];
+
         yield 'static method call' => [
             '<?php class Foo { static function hello(string $foo, int $bar) {} }; Foo::hello(<>',
             new SignatureHelp(

--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseSignatureHelperTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseSignatureHelperTest.php
@@ -106,21 +106,6 @@ class WorseSignatureHelperTest extends IntegrationTestCase
             )
         ];
 
-        yield 'function with parameters, 2nd active 1' => [
-            '<?php function hello(string $foo, int $bar) {}; hello("hello",<>',
-            new SignatureHelp(
-                [new SignatureInformation(
-                    'hello(string $foo, int $bar)',
-                    [
-                        new ParameterInformation('foo', 'string $foo'),
-                        new ParameterInformation('bar', 'int $bar'),
-                    ]
-                )],
-                0,
-                1
-            )
-        ];
-
         yield 'static method call' => [
             '<?php class Foo { static function hello(string $foo, int $bar) {} }; Foo::hello(<>',
             new SignatureHelp(
@@ -232,10 +217,10 @@ class WorseSignatureHelperTest extends IntegrationTestCase
 
         yield 'class with namespaced' => [
             <<<'EOT'
-<?php 
+<?php
 namespace Bar {
     class Foo {
-        public function __construct(string $foo, int $bar) 
+        public function __construct(string $foo, int $bar)
         {}
     }
 };


### PR DESCRIPTION
I noticed there was a problem when an argument was a string containing a comma:
The argument count was off because the comma was interpreted as an argument separator.

So I tried to look around for examples on uncommon cases that might not been handled: nested calls, multiline arguments, etc.
I found some cases that was not handled so add a few more tests.

I try to explain my logic when it come to solving the issues in the commit message, don't hesitate to check it out.

There one case that might be a personal preference and I don't know how it should behave.
So any one reading this, please gave us your opinion so we can try to choose the more commonly accepted behavior:
```php
<?php
function hello(string $foo, int $bar) {};
function goodbye(string $good, int $by) {};
hello(
    "hello",
    goo<>dbye("good", "by")
);
```

`<>` being the cursor position when we ask for the signature to be resolved.
I personally expect to have this result:
<pre>hello(string $foo, int <ins>$bar</ins>)</pre>

But I get that it can be confusing since:
```php
<?php
function hello(string $foo, int $bar) {};
he<>llo("hello", 1);
```
Would resolved as:
```
hellow(string $foo, int $bar)
```

I guess it can be sum up to, would you gave the priority to resolve the signature of:
* the call expression the cursor is **on**
* the call expression the cursor is **inside of**