### PR TITLE
[Improvement] completion handle aliases

### DIFF
--- a/lib/Bridge/TolerantParser/ChainTolerantCompletor.php
+++ b/lib/Bridge/TolerantParser/ChainTolerantCompletor.php
@@ -5,7 +5,9 @@ namespace Phpactor\Completion\Bridge\TolerantParser;
 use Generator;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Parser;
+use Microsoft\PhpParser\ResolvedName;
 use Phpactor\Completion\Core\Completor;
+use Phpactor\Completion\Core\Suggestion;
 use Phpactor\Completion\Core\Util\OffsetHelper;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
@@ -54,8 +56,9 @@ class ChainTolerantCompletor implements Completor
             }
 
             $suggestions = $tolerantCompletor->complete($completionNode, $source, $byteOffset);
-
-            yield from $suggestions;
+            foreach ($suggestions as $suggestion) {
+                yield $this->resolveClassSuggestion($completionNode, $suggestion);
+            }
 
             $isComplete = $isComplete && $suggestions->getReturn();
         }
@@ -70,10 +73,10 @@ class ChainTolerantCompletor implements Completor
         // ` will evaluate the Variable node as an expression node with a
         // double variable `$\n    $bar = `
         $truncatedSource = substr($source, 0, $byteOffset);
-        
+
         // determine the last non-whitespace _character_ offset
         $characterOffset = OffsetHelper::lastNonWhitespaceCharacterOffset($truncatedSource);
-        
+
         // truncate the source at the character offset
         $truncatedSource = mb_substr($source, 0, $characterOffset);
 
@@ -89,5 +92,50 @@ class ChainTolerantCompletor implements Completor
 
             return $completor->qualifier()->couldComplete($node);
         });
+    }
+
+    private function resolveClassSuggestion(Node $completionNode, Suggestion $suggestion): Suggestion
+    {
+        if (Suggestion::TYPE_CLASS !== $suggestion->type()) {
+            return $suggestion;
+        }
+
+        /** @var ResolvedName[] $importTable */
+        [$importTable] = $completionNode->getImportTablesForCurrentScope();
+
+        // Prioritize import without alias
+        if (isset($importTable[$suggestion->name()])) {
+            return $suggestion->withoutNameImport();
+        }
+
+        $suggestionFqcn = $suggestion->classImport();
+        $possibleMatches = [];
+        foreach ($importTable as $alias => $resolvedName) {
+            $importFqcn = $resolvedName->getFullyQualifiedNameText();
+
+            if ($suggestionFqcn === $importFqcn) {
+                return $suggestion->withoutNameImport()->withName($alias);
+            }
+
+            if (0 === strpos($suggestionFqcn, $importFqcn)) {
+                $possibleMatches[$alias] = $importFqcn;
+            }
+        }
+
+        if (!$possibleMatches) {
+            return $suggestion;
+        }
+
+        // Sort the possible by matches by FQCN length
+        uasort($possibleMatches, function (string $firstFqcn, $secondFqcn) {
+            return strlen($firstFqcn) <=> strlen($secondFqcn);
+        });
+
+        // Keep the match with the longest FQCN (more accurate one)
+        $importFqcn = end($possibleMatches);
+        $alias = array_key_last($possibleMatches);
+        $name = $alias.substr($suggestionFqcn, strlen($importFqcn));
+
+        return $suggestion->withoutNameImport()->withName($name);
     }
 }

--- a/lib/Bridge/TolerantParser/ResolveAliasSuggestionsTrait.php
+++ b/lib/Bridge/TolerantParser/ResolveAliasSuggestionsTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Phpactor\Completion\Bridge\TolerantParser;
+
+use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\ResolvedName;
+use Phpactor\Completion\Core\Suggestion;
+
+trait ResolveAliasSuggestionsTrait
+{
+    /**
+     * Add suggestions when a class is already imported with an alias or when a relative name is abailable.
+     *
+     * Will update the suggestion to remove the import_name option if already imported.
+     * Will add a suggestion if the class is imported under an alias.
+     * Will add a suggestion if part of the namespace is imported (i.e. ORM\Column is a relative name).
+     *
+     * @param ResolvedName[] $importTable
+     *
+     * @return Suggestion[]
+     */
+    private function resolveAliasSuggestions(array $importTable, Suggestion $suggestion): array
+    {
+        if (Suggestion::TYPE_CLASS !== $suggestion->type()) {
+            return [$suggestion];
+        }
+
+        $suggestionFqcn = $suggestion->classImport();
+        $suggestions = [$suggestion->name() => $suggestion];
+        foreach ($importTable as $alias => $resolvedName) {
+            $importFqcn = $resolvedName->getFullyQualifiedNameText();
+
+            if (0 !== strpos($suggestionFqcn, $importFqcn)) {
+                continue;
+            }
+
+            $name = $alias.substr($suggestionFqcn, strlen($importFqcn));
+
+            $suggestions[$alias] = $suggestion->withoutNameImport()->withName($name);
+        }
+
+        return array_values($suggestions);
+    }
+
+    /**
+     * @return ResolvedName[]
+     */
+    private function getClassImportTablesForNode(Node $node): array
+    {
+        try {
+            [$importTable] = $node->getImportTablesForCurrentScope();
+        } catch (\Exception $e) {
+            $importTable = [];
+        }
+
+        return $importTable;
+    }
+}

--- a/lib/Bridge/TolerantParser/TolerantCompletor.php
+++ b/lib/Bridge/TolerantParser/TolerantCompletor.php
@@ -11,7 +11,7 @@ use Phpactor\TextDocument\TextDocument;
 interface TolerantCompletor
 {
     /**
-     * @return Generator & iterable<Suggestion>
+     * @return Suggestion[]|Generator<int, Suggestion, null, bool>
      */
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator;
 }

--- a/lib/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
@@ -6,12 +6,12 @@ use Generator;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\SourceFileNode;
 use Microsoft\PhpParser\Parser;
+use Phpactor\Completion\Bridge\TolerantParser\ResolveAliasSuggestionsTrait;
 use Phpactor\Completion\Core\Completor;
 use Phpactor\Completion\Core\Completor\NameSearcherCompletor;
 use Phpactor\Completion\Core\Suggestion;
 use Phpactor\Completion\Core\Util\OffsetHelper;
 use Phpactor\ReferenceFinder\NameSearcher;
-use Phpactor\ReferenceFinder\Search\NameSearchResult;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
@@ -19,6 +19,8 @@ use Phpactor\WorseReflection\Reflector;
 
 class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Completor
 {
+    use ResolveAliasSuggestionsTrait;
+
     /**
      * @var Reflector
      */
@@ -61,6 +63,7 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
             return true;
         }
 
+        $importTable = $this->getClassImportTablesForNode($node);
         $suggestions = $this->completeName($annotation);
 
         foreach ($suggestions as $suggestion) {
@@ -68,17 +71,13 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
                 continue;
             }
 
-            yield $suggestion;
+            $resolvedSuggestions = $this->resolveAliasSuggestions($importTable, $suggestion);
+            foreach ($resolvedSuggestions as $resolvedSuggestion) {
+                yield $resolvedSuggestion->withSnippet($resolvedSuggestion->name().'($1)$0');
+            }
         }
 
         return $suggestions->getReturn();
-    }
-
-    protected function createSuggestionOptions(NameSearchResult $result): array
-    {
-        return array_merge(parent::createSuggestionOptions($result), [
-            'snippet' => (string) $result->name()->head() .'($1)$0',
-        ]);
     }
 
     private function truncateSource(string $source, int $byteOffset): string

--- a/lib/Core/Suggestion.php
+++ b/lib/Core/Suggestion.php
@@ -146,6 +146,14 @@ class Suggestion
         return $suggestion;
     }
 
+    public function withSnippet(string $snippet): self
+    {
+        $suggestion = clone $this;
+        $suggestion->snippet = $snippet;
+
+        return $suggestion;
+    }
+
     public function toArray(): array
     {
         return [

--- a/lib/Core/Suggestion.php
+++ b/lib/Core/Suggestion.php
@@ -46,7 +46,7 @@ class Suggestion
     private $shortDescription;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $label;
 
@@ -83,7 +83,7 @@ class Suggestion
         $this->type = $type;
         $this->name = $name;
         $this->shortDescription = $shortDescription;
-        $this->label = $label ?: $name;
+        $this->label = $label;
         $this->range = $range;
         $this->documentation = $documentation;
         $this->snippet = $snippet;
@@ -128,6 +128,22 @@ class Suggestion
             $options['range'],
             $options['snippet']
         );
+    }
+
+    public function withName(string $name): self
+    {
+        $suggestion = clone $this;
+        $suggestion->name = $name;
+
+        return $suggestion;
+    }
+
+    public function withoutNameImport(): self
+    {
+        $suggestion = clone $this;
+        $suggestion->nameImport = null;
+
+        return $suggestion;
     }
 
     public function toArray(): array
@@ -185,10 +201,9 @@ class Suggestion
         return $this->nameImport;
     }
 
-
     public function label(): string
     {
-        return $this->label;
+        return $this->label ?: $this->name;
     }
 
     public function range(): ?Range

--- a/tests/Integration/Bridge/TolerantParser/DoctrineAnnotationCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/DoctrineAnnotationCompletorTest.php
@@ -104,7 +104,45 @@ EOT
                 'type' => Suggestion::TYPE_CLASS,
                 'name' => 'Entity',
                 'short_description' => 'App\Annotation\Entity',
-                'snippet' => 'Entity($1)$0'
+                'snippet' => 'Entity($1)$0',
+                'name_import' => 'App\Annotation\Entity',
+            ]
+        ]];
+
+
+        yield 'in a namespace with an import' => [
+            <<<'EOT'
+<?php
+
+namespace App\Annotation;
+
+/**
+ * @Annotation
+ */
+class Entity {}
+
+namespace App;
+
+use App\Annotation as APP;
+
+/**
+ * @Ent<>
+ */
+class Foo {}
+EOT
+        , [
+            [
+                'type' => Suggestion::TYPE_CLASS,
+                'name' => 'APP\Entity',
+                'short_description' => 'App\Annotation\Entity',
+                'snippet' => 'APP\Entity($1)$0',
+                'name_import' => null,
+            ], [
+                'type' => Suggestion::TYPE_CLASS,
+                'name' => 'Entity',
+                'short_description' => 'App\Annotation\Entity',
+                'snippet' => 'Entity($1)$0',
+                'name_import' => 'App\Annotation\Entity',
             ]
         ]];
 

--- a/tests/Unit/Core/SuggestionTest.php
+++ b/tests/Unit/Core/SuggestionTest.php
@@ -66,4 +66,27 @@ class SuggestionTest extends TestCase
             'name_import' => 'Namespace\\Foobar',
         ], $suggestion->toArray());
     }
+
+    public function testWithName()
+    {
+        $suggestion = Suggestion::create('name')->withName('test');
+        $this->assertEquals('test', $suggestion->name());
+        $this->assertEquals('test', $suggestion->label());
+
+        $suggestion = Suggestion::createWithOptions(
+            'name',
+            ['label' => 'label'],
+        )->withName('test');
+        $this->assertEquals('test', $suggestion->name());
+        $this->assertEquals('label', $suggestion->label());
+    }
+
+    public function testWithoutNameImport()
+    {
+        $suggestion = Suggestion::createWithOptions(
+            'name',
+            ['name_import' => 'previous'],
+        )->withoutNameImport();
+        $this->assertNull($suggestion->nameImport());
+    }
 }

--- a/tests/Unit/Core/SuggestionTest.php
+++ b/tests/Unit/Core/SuggestionTest.php
@@ -89,4 +89,13 @@ class SuggestionTest extends TestCase
         )->withoutNameImport();
         $this->assertNull($suggestion->nameImport());
     }
+
+    public function testWithSnippet()
+    {
+        $suggestion = Suggestion::createWithOptions(
+            'name',
+            ['snippet' => 'snippet'],
+        )->withSnippet('test');
+        $this->assertEquals('test', $suggestion->snippet());
+    }
 }


### PR DESCRIPTION
Hi,

That's an attempt to deal with aliases from the import table when completing classes (see https://github.com/phpactor/phpactor/issues/1121).
I tried to not keep it as clean as possible but it still kind of a POC to see how you feel about the idea so don't hesitate: the more critics the better :smile: 

I decided to put it on the `ChainTolerantCompletor` because we need the parser to get the import table and I wanted it to work for all class completors without having to deal with them one by one.

The new `DoctrineAnnotationCompletor` is a bit special so I had to extract the logic into a trait.
As I said in the commit message I did it to because it feels a right use case but if you prefer an helper class with static methods it's also possible of course.

I've mainly used the automated test for now, just one or two manual test in a demo project to make sure it works.
I will update my work environment on Monday so that I can test it in a more realistic code base.