### PR TITLE
Support sorting by file path similarity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpactor/class-to-file": "~0.3",
         "phpactor/container": "^1.0",
         "phpactor/logging-extension": "~0.1",
-        "phpactor/reference-finder": "^0.1.4",
+        "phpactor/reference-finder": "^0.1.5",
         "phpactor/rpc-extension": "~0.1",
         "phpactor/source-code-filesystem": "~0.1",
         "phpactor/text-document": "^1.0",

--- a/lib/Bridge/TolerantParser/ReferenceFinder/NameSearcherCompletor.php
+++ b/lib/Bridge/TolerantParser/ReferenceFinder/NameSearcherCompletor.php
@@ -16,7 +16,7 @@ class NameSearcherCompletor extends CoreNameSearcherCompletor implements Toleran
      */
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
     {
-        $suggestions = $this->completeName($node->getText());
+        $suggestions = $this->completeName($node->getText(), $source->uri());
 
         yield from $suggestions;
 

--- a/lib/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
@@ -14,6 +14,7 @@ use Phpactor\ReferenceFinder\NameSearcher;
 use Phpactor\ReferenceFinder\Search\NameSearchResult;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
+use Phpactor\TextDocument\TextDocumentUri;
 use Phpactor\WorseReflection\Core\Exception\NotFound;
 use Phpactor\WorseReflection\Reflector;
 
@@ -61,7 +62,7 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
             return true;
         }
 
-        $suggestions = $this->completeName($annotation);
+        $suggestions = $this->completeName($annotation, $source->uri());
 
         foreach ($suggestions as $suggestion) {
             if (!$this->isAnAnnotation($suggestion)) {
@@ -74,7 +75,7 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
         return $suggestions->getReturn();
     }
 
-    protected function createSuggestionOptions(NameSearchResult $result): array
+    protected function createSuggestionOptions(NameSearchResult $result, ?TextDocumentUri $sourceUri = null): array
     {
         return array_merge(parent::createSuggestionOptions($result), [
             'snippet' => (string) $result->name()->head() .'($1)$0',

--- a/lib/Core/Completor/NameSearcherCompletor.php
+++ b/lib/Core/Completor/NameSearcherCompletor.php
@@ -3,9 +3,12 @@
 namespace Phpactor\Completion\Core\Completor;
 
 use Generator;
+use Phpactor\Completion\Core\DocumentPrioritizer\DefaultResultPrioritizer;
+use Phpactor\Completion\Core\DocumentPrioritizer\DocumentPrioritizer;
 use Phpactor\Completion\Core\Suggestion;
 use Phpactor\ReferenceFinder\NameSearcher;
 use Phpactor\ReferenceFinder\Search\NameSearchResult;
+use Phpactor\TextDocument\TextDocumentUri;
 
 abstract class NameSearcherCompletor
 {
@@ -14,20 +17,26 @@ abstract class NameSearcherCompletor
      */
     protected $nameSearcher;
 
-    public function __construct(NameSearcher $nameSearcher)
+    /**
+     * @var DocumentPrioritizer
+     */
+    private $prioritizer;
+
+    public function __construct(NameSearcher $nameSearcher, DocumentPrioritizer $prioritizer = null)
     {
         $this->nameSearcher = $nameSearcher;
+        $this->prioritizer = $prioritizer ?: new DefaultResultPrioritizer();
     }
 
     /**
      * @return Generator<Suggestion>
      */
-    protected function completeName(string $name): Generator
+    protected function completeName(string $name, ?TextDocumentUri $sourceUri = null): Generator
     {
         foreach ($this->nameSearcher->search($name) as $result) {
             yield $this->createSuggestion(
                 $result,
-                $this->createSuggestionOptions($result),
+                $this->createSuggestionOptions($result, $sourceUri),
             );
         }
 
@@ -41,14 +50,14 @@ abstract class NameSearcherCompletor
         return Suggestion::createWithOptions($result->name()->head(), $options);
     }
 
-    protected function createSuggestionOptions(NameSearchResult $result): array
+    protected function createSuggestionOptions(NameSearchResult $result, ?TextDocumentUri $sourceUri = null): array
     {
         return [
             'short_description' => $result->name()->__toString(),
             'type' => $this->suggestionType($result),
             'class_import' => $this->classImport($result),
             'name_import' => $result->name()->__toString(),
-            'priority' => Suggestion::PRIORITY_LOW,
+            'priority' => $this->prioritizer->priority($result->uri(), $sourceUri)
         ];
     }
 

--- a/lib/Core/DocumentPrioritizer/DefaultResultPrioritizer.php
+++ b/lib/Core/DocumentPrioritizer/DefaultResultPrioritizer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Phpactor\Completion\Core\DocumentPrioritizer;
+
+use Phpactor\Completion\Core\Suggestion;
+use Phpactor\TextDocument\TextDocumentUri;
+
+class DefaultResultPrioritizer implements DocumentPrioritizer
+{
+    /**
+     * @var int
+     */
+    private $priority;
+
+    public function __construct(int $priority = Suggestion::PRIORITY_LOW)
+    {
+        $this->priority = $priority;
+    }
+
+    public function priority(?TextDocumentUri $one, ?TextDocumentUri $two): int
+    {
+        return $this->priority;
+    }
+}

--- a/lib/Core/DocumentPrioritizer/DocumentPrioritizer.php
+++ b/lib/Core/DocumentPrioritizer/DocumentPrioritizer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Phpactor\Completion\Core\DocumentPrioritizer;
+
+use Phpactor\TextDocument\TextDocumentUri;
+
+interface DocumentPrioritizer
+{
+    public function priority(?TextDocumentUri $one, ?TextDocumentUri $two): int;
+}

--- a/lib/Core/DocumentPrioritizer/SimilarityResultPrioritizer.php
+++ b/lib/Core/DocumentPrioritizer/SimilarityResultPrioritizer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Phpactor\Completion\Core\DocumentPrioritizer;
+
+use Phpactor\Completion\Core\Suggestion;
+use Phpactor\TextDocument\TextDocumentUri;
+
+/**
+ * Compare the similarity between two paths and provide a suggestion priority
+ * based on the similarity.
+ *
+ * This is used to compare the text document being edited and the suggestion.
+ * Classes that are closer in the source tree will be suggested first.
+ *
+ * The result is weighted from MEDIUM to HIGH
+ */
+class SimilarityResultPrioritizer implements DocumentPrioritizer
+{
+    public function priority(?TextDocumentUri $one, ?TextDocumentUri $two): int
+    {
+        if (null === $one) {
+            return Suggestion::PRIORITY_LOW;
+        }
+
+        if (null === $two) {
+            return Suggestion::PRIORITY_LOW;
+        }
+
+        $e1 = explode('/', $one->path());
+        $e2 = explode('/', $two->path());
+        $e3 = array_intersect($e1, $e2);
+        $max = max(count($e1), count($e2));
+        $similarity = (1 / $max) * count($e3);
+
+        $range = Suggestion::PRIORITY_LOW - Suggestion::PRIORITY_MEDIUM;
+
+        return Suggestion::PRIORITY_MEDIUM + $range - $range * $similarity;
+    }
+}

--- a/lib/Core/Sort/TextDocumentUriSort.php
+++ b/lib/Core/Sort/TextDocumentUriSort.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Phpactor\Completion\Core\Sort;
+
+class TextDocumentUriSort
+{
+}

--- a/tests/Unit/Core/DocumentPrioritizer/SimilarityResultPrioritizerTest.php
+++ b/tests/Unit/Core/DocumentPrioritizer/SimilarityResultPrioritizerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Phpactor\Completion\Tests\Unit\Core\DocumentPrioritizer;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Phpactor\Completion\Core\DocumentPrioritizer\SimilarityResultPrioritizer;
+use Phpactor\Completion\Core\Suggestion;
+use Phpactor\TextDocument\TextDocumentUri;
+
+class SimilarityResultPrioritizerTest extends TestCase
+{
+    /**
+     * @dataProvider providePriority
+     */
+    public function testPriority(?TextDocumentUri $one, ?TextDocumentUri $two, int $priority): void
+    {
+        self::assertEquals($priority, (new SimilarityResultPrioritizer())->priority($one, $two));
+    }
+        
+    /**
+     * @return Generator<mixed>
+     */
+    public function providePriority(): Generator
+    {
+        yield [
+                null,
+                null,
+                Suggestion::PRIORITY_LOW
+            ];
+        yield [
+                TextDocumentUri::fromString('/home/daniel/phpactor/vendor/symfony/foobar/lib/ClassOne.php'),
+                TextDocumentUri::fromString('/home/daniel/phpactor/lib/ClassOne.php'),
+                169 // higher priority for non matching
+            ];
+        yield [
+                TextDocumentUri::fromString('/home/daniel/phpactor/vendor/symfony/foobar/lib/ClassOne.php'),
+                TextDocumentUri::fromString('/home/daniel/phpactor/vendor/symfony/foobar/lib/ClassOne.php'),
+                Suggestion::PRIORITY_MEDIUM // exact match gives baseline of medium priority (127)
+            ];
+    }
+}


### PR DESCRIPTION
(**note** I introduced "priority" this morning. It can be specified for each result from `Suggestion::PRIORITY_LOW` to `Suggestion::PRIORITY_HIGH`. The languaeg server will use it to generate the sort text.)

This PR introduces support for sorting name results (i.e. class names, function anmes) based on their file-path similarity to the text document under completion.

This gives the option to sort class names by proximity to the text document being edited. I will make this configurable

cc @camilledejoye 

