### PR TITLE
Add builtin function snippets

### DIFF
--- a/lib/Bridge/TolerantParser/ReferenceFinder/NameSearcherCompletor.php
+++ b/lib/Bridge/TolerantParser/ReferenceFinder/NameSearcherCompletor.php
@@ -6,11 +6,31 @@ use Generator;
 use Microsoft\PhpParser\Node;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
 use Phpactor\Completion\Core\Completor\NameSearcherCompletor as CoreNameSearcherCompletor;
+use Phpactor\Completion\Core\DocumentPrioritizer\DocumentPrioritizer;
+use Phpactor\Completion\Core\Formatter\NameSearchResultFunctionSnippetFormatter;
+use Phpactor\ReferenceFinder\NameSearcher;
+use Phpactor\ReferenceFinder\Search\NameSearchResult;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;
+use Phpactor\TextDocument\TextDocumentUri;
 
 class NameSearcherCompletor extends CoreNameSearcherCompletor implements TolerantCompletor
 {
+    /**
+     * @var NameSearchResultFunctionSnippetFormatter
+     */
+    private $snippetFormatter;
+
+    public function __construct(
+        NameSearcher $nameSearcher,
+        NameSearchResultFunctionSnippetFormatter $snippetFormatter,
+        DocumentPrioritizer $prioritizer = null
+    ) {
+        parent::__construct($nameSearcher, $prioritizer);
+
+        $this->snippetFormatter = $snippetFormatter;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -21,5 +41,21 @@ class NameSearcherCompletor extends CoreNameSearcherCompletor implements Toleran
         yield from $suggestions;
 
         return $suggestions->getReturn();
+    }
+
+    protected function createSuggestionOptions(NameSearchResult $result, ?TextDocumentUri $sourceUri = null): array
+    {
+        $suggestions = parent::createSuggestionOptions($result, $sourceUri);
+
+        if ($this->snippetFormatter->canFormat($result)) {
+            return array_merge(
+                $suggestions,
+                [
+                    'snippet' => $this->snippetFormatter->format($result)
+                ]
+            );
+        }
+
+        return $suggestions;
     }
 }

--- a/lib/Core/Formatter/NameSearchResultFunctionSnippetFormatter.php
+++ b/lib/Core/Formatter/NameSearchResultFunctionSnippetFormatter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Phpactor\Completion\Core\Formatter;
+
+use Phpactor\ReferenceFinder\Search\NameSearchResult;
+use Phpactor\WorseReflection\Reflector;
+
+class NameSearchResultFunctionSnippetFormatter
+{
+    /**
+     * @var ObjectFormatter
+     */
+    private $objectFormatter;
+
+    /**
+     * @var Reflector
+     */
+    private $reflector;
+
+    public function __construct(ObjectFormatter $objectFormatter, Reflector $reflector)
+    {
+        $this->objectFormatter = $objectFormatter;
+        $this->reflector = $reflector;
+    }
+
+    public function canFormat(object $object): bool
+    {
+        return $object instanceof NameSearchResult
+            && $object->type()->isFunction();
+    }
+
+    public function format(object $object): string
+    {
+        assert($object instanceof NameSearchResult);
+        $functionName = $object->name()->__toString();
+        $functionReflection = $this->reflector->reflectFunction($functionName);
+        return $this->objectFormatter->format($functionReflection);
+    }
+}


### PR DESCRIPTION
To be honest I don't really have a clue what I am doing here ;)  
I found that the "NameSearcher" doesn't add snippets → is now implemented.

Relates to https://github.com/phpactor/phpactor/issues/1230

Once this has been released I will file a PR with an update for "completion-worse-extension".