### PR TITLE
Remove alias completor min width requirement

### DIFF
--- a/lib/Bridge/TolerantParser/WorseReflection/WorseClassAliasCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseClassAliasCompletor.php
@@ -30,7 +30,7 @@ class WorseClassAliasCompletor implements TolerantCompletor, TolerantQualifiable
     public function __construct(Reflector $reflector, ?ClassQualifier $qualifier = null)
     {
         $this->reflector = $reflector;
-        $this->qualifier = $qualifier ?: new ClassQualifier();
+        $this->qualifier = $qualifier ?: new ClassQualifier(0);
     }
 
     public function complete(Node $node, TextDocument $source, ByteOffset $offset): Generator
@@ -39,6 +39,7 @@ class WorseClassAliasCompletor implements TolerantCompletor, TolerantQualifiable
 
         /** @var ResolvedName $resolvedName */
         foreach ($namespaceImports as $alias => $resolvedName) {
+            
             $parts = $resolvedName->getNameParts();
             if (empty($parts)) {
                 continue;

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseClassAliasCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseClassAliasCompletor.php
@@ -39,7 +39,6 @@ class WorseClassAliasCompletor implements TolerantCompletor, TolerantQualifiable
 
         /** @var ResolvedName $resolvedName */
         foreach ($namespaceImports as $alias => $resolvedName) {
-            
             $parts = $resolvedName->getNameParts();
             if (empty($parts)) {
                 continue;


### PR DESCRIPTION
It currently uses the default constructor of `ClassQualifier` which imposes a minimum length of 3 before it allows completion which makes no sense because classes appear immediately, but aliases appear after 3 letters.

Resolves https://github.com/phpactor/phpactor/issues/1219.