### PR TITLE
fix class snippets

### DIFF
--- a/lib/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/DoctrineAnnotationCompletor.php
@@ -75,9 +75,12 @@ class DoctrineAnnotationCompletor extends NameSearcherCompletor implements Compl
         return $suggestions->getReturn();
     }
 
-    protected function createSuggestionOptions(NameSearchResult $result, ?TextDocumentUri $sourceUri = null): array
-    {
-        return array_merge(parent::createSuggestionOptions($result), [
+    protected function createSuggestionOptions(
+        NameSearchResult $result,
+        ?TextDocumentUri $sourceUri = null,
+        ?Node $node = null
+    ): array {
+        return array_merge(parent::createSuggestionOptions($result, null, $node), [
             'snippet' => (string) $result->name()->head() .'($1)$0',
         ]);
     }

--- a/lib/Core/Completor/NameSearcherCompletor.php
+++ b/lib/Core/Completor/NameSearcherCompletor.php
@@ -3,6 +3,7 @@
 namespace Phpactor\Completion\Core\Completor;
 
 use Generator;
+use Microsoft\PhpParser\Node;
 use Phpactor\Completion\Core\DocumentPrioritizer\DefaultResultPrioritizer;
 use Phpactor\Completion\Core\DocumentPrioritizer\DocumentPrioritizer;
 use Phpactor\Completion\Core\Suggestion;
@@ -31,27 +32,31 @@ abstract class NameSearcherCompletor
     /**
      * @return Generator<Suggestion>
      */
-    protected function completeName(string $name, ?TextDocumentUri $sourceUri = null): Generator
+    protected function completeName(string $name, ?TextDocumentUri $sourceUri = null, ?Node $node = null): Generator
     {
         foreach ($this->nameSearcher->search($name) as $result) {
             yield $this->createSuggestion(
                 $result,
-                $this->createSuggestionOptions($result, $sourceUri),
+                $node,
+                $this->createSuggestionOptions($result, $sourceUri, $node),
             );
         }
 
         return true;
     }
 
-    protected function createSuggestion(NameSearchResult $result, array $options = []): Suggestion
+    protected function createSuggestion(NameSearchResult $result, ?Node $node = null, array $options = []): Suggestion
     {
-        $options = array_merge($this->createSuggestionOptions($result), $options);
+        $options = array_merge($this->createSuggestionOptions($result, null, $node), $options);
 
         return Suggestion::createWithOptions($result->name()->head(), $options);
     }
 
-    protected function createSuggestionOptions(NameSearchResult $result, ?TextDocumentUri $sourceUri = null): array
-    {
+    protected function createSuggestionOptions(
+        NameSearchResult $result,
+        ?TextDocumentUri $sourceUri = null,
+        ?Node $node = null
+    ): array {
         return [
             'short_description' => $result->name()->__toString(),
             'type' => $this->suggestionType($result),

--- a/tests/Integration/Bridge/TolerantParser/ReferenceFinder/NameSearcherCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/ReferenceFinder/NameSearcherCompletorTest.php
@@ -24,7 +24,7 @@ class NameSearcherCompletorTest extends TolerantCompletorTestCase
 
     public function provideComplete(): Generator
     {
-        yield 'class' => [
+        yield 'new class instance' => [
             '<?php class Foobar { public function __construct(int $cparam) {} } :int {}; new Foo<>', [
                 [
                     'type'              => Suggestion::TYPE_CLASS,
@@ -34,13 +34,22 @@ class NameSearcherCompletorTest extends TolerantCompletorTestCase
                 ]
             ]
         ];
-        yield 'class (empty constructor)' => [
+        yield 'new class instance (empty constructor)' => [
             '<?php class Foobar { public function __construct() {} } :int {}; new Foo<>', [
                 [
                     'type'              => Suggestion::TYPE_CLASS,
                     'name'              => 'Foobar',
                     'short_description' => 'Foobar',
                     'snippet'           => 'Foobar()',
+                ]
+            ]
+        ];
+        yield 'class typehint (no instantiation)' => [
+            '<?php class Foobar { public function __construct() {} } :int {}; Fo<>', [
+                [
+                    'type'              => Suggestion::TYPE_CLASS,
+                    'name'              => 'Foobar',
+                    'short_description' => 'Foobar',
                 ]
             ]
         ];
@@ -74,6 +83,9 @@ class NameSearcherCompletorTest extends TolerantCompletorTestCase
             NameSearchResult::create('class', 'Foobar')
         ]);
         $searcher->search('Foo')->willYield([
+            NameSearchResult::create('class', 'Foobar')
+        ]);
+        $searcher->search('Fo')->willYield([
             NameSearchResult::create('class', 'Foobar')
         ]);
         $searcher->search('ba')->willYield([

--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
@@ -42,6 +42,7 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 'type' => Suggestion::TYPE_PROPERTY,
                 'name' => 'foo',
                 'short_description' => 'pub $foo',
+                'snippet' => null
             ]
         ]
     ];
@@ -218,6 +219,7 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 'type' => Suggestion::TYPE_METHOD,
                 'name' => 'foo',
                 'short_description' => 'pub foo(): Foobar',
+                'snippet' => 'foo()',
             ]
         ]
     ];

--- a/tests/Integration/CompletorTestCase.php
+++ b/tests/Integration/CompletorTestCase.php
@@ -39,7 +39,11 @@ abstract class CompletorTestCase extends IntegrationTestCase
 
         $this->assertCount(count($expected), $suggestions);
         foreach ($expected as $index => $expectedSuggestion) {
-            $this->assertArraySubset($expectedSuggestion, $suggestions[$index]->toArray());
+            $actual = $suggestions[$index]->toArray();
+            $this->assertArraySubset($expectedSuggestion, $actual);
+            if (array_key_exists('snippet', $expectedSuggestion) === false) {
+                self::assertEmpty($actual['snippet'], 'got unexpected snippet "' . $actual['snippet'] . '"');
+            }
         }
 
         $this->assertCount(count($expected), $suggestions);


### PR DESCRIPTION
Do not create snippets for class results that do not belong to an object creation expression.

See https://github.com/phpactor/completion/pull/52#issuecomment-825166905