### PR TITLE
Fix method completion

### DIFF
--- a/lib/Bridge/TolerantParser/ChainTolerantCompletor.php
+++ b/lib/Bridge/TolerantParser/ChainTolerantCompletor.php
@@ -37,7 +37,7 @@ class ChainTolerantCompletor implements Completor
 
         $node = $this->parser->parseSourceFile($truncatedSource)->getDescendantNodeAtPosition(
             // the parser requires the byte offset, not the char offset
-            min(strlen($truncatedSource), $byteOffset->toInt())
+            strlen($truncatedSource)
         );
 
         $isComplete = true;

--- a/lib/Bridge/TolerantParser/ChainTolerantCompletor.php
+++ b/lib/Bridge/TolerantParser/ChainTolerantCompletor.php
@@ -6,7 +6,6 @@ use Generator;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Parser;
 use Phpactor\Completion\Core\Completor;
-use Phpactor\Completion\Core\Suggestion;
 use Phpactor\Completion\Core\Util\OffsetHelper;
 use Phpactor\TextDocument\ByteOffset;
 use Phpactor\TextDocument\TextDocument;

--- a/lib/Bridge/TolerantParser/ChainTolerantCompletor.php
+++ b/lib/Bridge/TolerantParser/ChainTolerantCompletor.php
@@ -65,11 +65,11 @@ class ChainTolerantCompletor implements Completor
 
     private function truncateSource(string $source, int $byteOffset): string
     {
-        // truncate source at the line where byte offset is - we don't want the rest of the source
+        // truncate source at the byte offset - we don't want the rest of the source
         // file contaminating the completion (for example `$foo($<>\n    $bar =
         // ` will evaluate the Variable node as an expression node with a
         // double variable `$\n    $bar = `
-        $truncatedSource = substr($source, 0, strpos($source, "\n", $byteOffset) ?: $byteOffset);
+        $truncatedSource = substr($source, 0, $byteOffset);
         
         // determine the last non-whitespace _character_ offset
         $characterOffset = OffsetHelper::lastNonWhitespaceCharacterOffset($truncatedSource);

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -82,8 +82,8 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
         }
 
         $callExpression = $node->getParent();
-        if($callExpression instanceof CallExpression) {
-            $shouldCompleteOnlyName = 
+        if ($callExpression instanceof CallExpression) {
+            $shouldCompleteOnlyName =
                 $callExpression->openParen !== null &&
                 $callExpression->callableExpression == $node;
         } else {

--- a/lib/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletor.php
@@ -4,7 +4,6 @@ namespace Phpactor\Completion\Bridge\TolerantParser\WorseReflection;
 
 use Generator;
 use Microsoft\PhpParser\Node;
-use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Token;
 use Phpactor\Completion\Bridge\TolerantParser\Qualifier\ClassMemberQualifier;
@@ -82,7 +81,7 @@ class WorseClassMemberCompletor implements TolerantCompletor, TolerantQualifiabl
             return true;
         }
         
-        $shouldCompleteOnlyName = strlen($source) > $offset->toInt() && substr($source, $offset->toInt(), 1) == "(";
+        $shouldCompleteOnlyName = strlen($source) > $offset->toInt() && substr($source, $offset->toInt(), 1) == '(';
         
         $partialMatch = (string) $memberName->getText($node->getFileContents());
 

--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
@@ -218,6 +218,7 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                     'type' => Suggestion::TYPE_METHOD,
                     'name' => 'foo',
                     'short_description' => 'pub foo(): Foobar',
+                    'snippet' => 'foo()',
                 ]
             ]
         ];

--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
@@ -37,15 +37,14 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar-><>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_PROPERTY,
-                'name' => 'foo',
-                'short_description' => 'pub $foo',
-                'snippet' => null
+            , [
+                [
+                    'type' => Suggestion::TYPE_PROPERTY,
+                    'name' => 'foo',
+                    'short_description' => 'pub $foo',
+                ]
             ]
-        ]
-    ];
+        ];
 
         yield 'Private property' => [
             <<<'EOT'
@@ -60,7 +59,7 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar-><>
 
                 EOT
-        ,
+            ,
             [ ]
         ];
 
@@ -76,8 +75,8 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 class Foobar
                 {
                     /**
-                     * @var Barar
-                     */
+                        * @var Barar
+                        */
                     public $foo;
                 }
 
@@ -85,14 +84,14 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar->foo-><>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_PROPERTY,
-                'name' => 'bar',
-                'short_description' => 'pub $bar',
+            , [
+                [
+                    'type' => Suggestion::TYPE_PROPERTY,
+                    'name' => 'bar',
+                    'short_description' => 'pub $bar',
+                ]
             ]
-        ]
-    ];
+        ];
 
         yield 'Public method with parameters' => [
             <<<'EOT'
@@ -109,15 +108,15 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar-><>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'foo',
-                'short_description' => 'pub foo(string $zzzbar = \'bar\', $def): Barbar',
-                'snippet' => 'foo(${1:\$def})${0}',
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'foo',
+                    'short_description' => 'pub foo(string $zzzbar = \'bar\', $def): Barbar',
+                    'snippet' => 'foo(${1:\$def})${0}',
+                ]
             ]
-        ]
-    ];
+        ];
 
         yield 'Public method multiple return types' => [
             <<<'EOT'
@@ -126,8 +125,8 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 class Foobar
                 {
                     /**
-                     * @return Foobar|Barbar
-                     */
+                    * @return Foobar|Barbar
+                    */
                     public function foo()
                     {
                     }
@@ -137,15 +136,15 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar-><>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'foo',
-                'short_description' => 'pub foo(): Foobar|Barbar',
-                'snippet' => 'foo()',
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'foo',
+                    'short_description' => 'pub foo(): Foobar|Barbar',
+                    'snippet' => 'foo()',
+                ]
             ]
-        ]
-    ];
+        ];
 
         yield 'Private method' => [
             <<<'EOT'
@@ -162,8 +161,8 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar-><>
 
                 EOT
-        , [
-        ]
+            , [
+            ]
         ];
 
         yield 'Public method with documentation' => [
@@ -186,15 +185,15 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar-><>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'foo',
-                'short_description' => 'pub foo(): Foobar|Barbar',
-                'documentation' => "Returns a foobar\n",
-                'snippet' => 'foo()',
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'foo',
+                    'short_description' => 'pub foo(): Foobar|Barbar',
+                    'documentation' => "Returns a foobar\n",
+                    'snippet' => 'foo()',
+                ]
             ]
-        ]
         ];
 
         yield 'Virtual method' => [
@@ -214,15 +213,14 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar-><>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'foo',
-                'short_description' => 'pub foo(): Foobar',
-                'snippet' => 'foo()',
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'foo',
+                    'short_description' => 'pub foo(): Foobar',
+                ]
             ]
-        ]
-    ];
+        ];
 
         yield 'Static property' => [
             <<<'EOT'
@@ -237,19 +235,19 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar::<>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_PROPERTY,
-                'name' => '$foo',
-                'short_description' => 'pub static $foo',
-            ],
-            [
-                'type' => Suggestion::TYPE_CONSTANT,
-                'name' => 'class',
-                'short_description' => 'Foobar',
-            ],
-        ]
-    ];
+            , [
+                [
+                    'type' => Suggestion::TYPE_PROPERTY,
+                    'name' => '$foo',
+                    'short_description' => 'pub static $foo',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CONSTANT,
+                    'name' => 'class',
+                    'short_description' => 'Foobar',
+                ],
+            ]
+        ];
 
         yield 'Static property with previous arrow accessor' => [
             <<<'EOT'
@@ -269,19 +267,71 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar->me::<>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_PROPERTY,
-                'name' => '$foo',
-                'short_description' => 'pub static $foo',
-            ],
-            [
-                'type' => Suggestion::TYPE_CONSTANT,
-                'name' => 'class',
-                'short_description' => 'Foobar',
-            ],
-        ]
-    ];
+            , [
+                [
+                    'type' => Suggestion::TYPE_PROPERTY,
+                    'name' => '$foo',
+                    'short_description' => 'pub static $foo',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CONSTANT,
+                    'name' => 'class',
+                    'short_description' => 'Foobar',
+                ],
+            ]
+        ];
+
+        yield 'Partially completed method with brackets' => [
+            <<<'EOT'
+                <?php
+
+                class Foobar
+                {
+                    public function aaa()
+                    {
+                        $this->bb<>();
+                    }
+
+                    public function bbb() {}
+                    public function ccc() {}
+                }
+
+                EOT
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'bbb',
+                    'short_description' => 'pub bbb()',
+                    'snippet' => 'bbb',
+                ]
+            ]
+        ];
+
+        yield 'Partially completed static method with brackets' => [
+            <<<'EOT'
+                <?php
+
+                class Foobar
+                {
+                    public function aaa()
+                    {
+                        self::bb<>();
+                    }
+
+                    public static function bbb() {}
+                    public static function ccc() {}
+                }
+
+                EOT
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'bbb',
+                    'short_description' => 'pub bbb()',
+                    'snippet' => 'bbb',
+                ]
+            ]
+        ];
 
         yield 'Partially completed 3' => [
             <<<'EOT'
@@ -297,14 +347,14 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar::$f<>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_PROPERTY,
-                'name' => '$foobar',
-                'short_description' => 'pub static $foobar',
+            , [
+                [
+                    'type' => Suggestion::TYPE_PROPERTY,
+                    'name' => '$foobar',
+                    'short_description' => 'pub static $foobar',
+                ]
             ]
-        ]
-    ];
+        ];
 
         yield 'Partially completed 2' => [
             <<<'EOT'
@@ -322,15 +372,16 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 }
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'bbb',
-                'short_description' => 'pub bbb()',
-                'snippet' => 'bbb()',
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'bbb',
+                    'short_description' => 'pub bbb()',
+                    'snippet' => 'bbb()',
+                ]
             ]
-        ]
-    ];
+        ];
+
         yield 'Partially completed' => [
             <<<'EOT'
                 <?php
@@ -345,24 +396,24 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar::<>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_CONSTANT,
-                'name' => 'BARFOO',
-                'short_description' => 'BARFOO = "barfoo"',
+            , [
+                [
+                    'type' => Suggestion::TYPE_CONSTANT,
+                    'name' => 'BARFOO',
+                    'short_description' => 'BARFOO = "barfoo"',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CONSTANT,
+                    'name' => 'FOOBAR',
+                    'short_description' => 'FOOBAR = "foobar"',
+                ],
+                [
+                    'type' => Suggestion::TYPE_CONSTANT,
+                    'name' => 'class',
+                    'short_description' => 'Foobar',
+                ],
             ],
-            [
-                'type' => Suggestion::TYPE_CONSTANT,
-                'name' => 'FOOBAR',
-                'short_description' => 'FOOBAR = "foobar"',
-            ],
-            [
-                'type' => Suggestion::TYPE_CONSTANT,
-                'name' => 'class',
-                'short_description' => 'Foobar',
-            ],
-        ],
-    ];
+        ];
 
         yield 'Accessor on new line' => [
             <<<'EOT'
@@ -378,14 +429,14 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                     ->    <>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_PROPERTY,
-                'name' => 'foobar',
-                'short_description' => 'pub $foobar',
+            , [
+                [
+                    'type' => Suggestion::TYPE_PROPERTY,
+                    'name' => 'foobar',
+                    'short_description' => 'pub $foobar',
+                ],
             ],
-        ],
-    ];
+        ];
 
         yield 'Completion on collection' => [
             <<<'EOT'
@@ -409,15 +460,15 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $collection-><>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'heyho',
-                'short_description' => 'pub heyho()',
-                'snippet' => 'heyho()',
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'heyho',
+                    'short_description' => 'pub heyho()',
+                    'snippet' => 'heyho()',
+                ],
             ],
-        ],
-    ];
+        ];
 
         yield 'Completion on assignment' => [
             <<<'EOT'
@@ -432,15 +483,15 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar = $foobar->meth<>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'method1',
-                'short_description' => 'pub method1()',
-                'snippet' => 'method1()',
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'method1',
+                    'short_description' => 'pub method1()',
+                    'snippet' => 'method1()',
+                ],
             ],
-        ],
-    ];
+        ];
 
         yield 'member is variable name' => [
             <<<'EOT'
@@ -463,8 +514,9 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $foobar = new Foobar();
                 $foobar->$bar<>;
                 EOT
-        , [
-        ]];
+            , [
+            ]
+        ];
 
         yield 'chained method call with arguments' => [
             <<<'EOT'
@@ -483,13 +535,14 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                     ->hello('one', 'two')
                     -><>
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'goodbye',
-                'snippet' => 'goodbye()',
-            ],
-        ]];
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'goodbye',
+                    'snippet' => 'goodbye()',
+                ],
+            ]
+        ];
 
         yield 'chained static method call with arguments' => [
             <<<'EOT'
@@ -507,13 +560,14 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                     ->hello('one', 'two')
                     -><>
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'goodbye',
-                'snippet' => 'goodbye()',
-            ],
-        ]];
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'goodbye',
+                    'snippet' => 'goodbye()',
+                ],
+            ]
+        ];
 
         yield 'instance member on static method' => [
             <<<'EOT'
@@ -527,18 +581,19 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 BarBar::<>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_CONSTANT,
-                'name' => 'class',
-                'short_description' => 'BarBar',
-            ],
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'hello',
-                'snippet' => 'hello()',
-            ],
-        ]];
+            , [
+                [
+                    'type' => Suggestion::TYPE_CONSTANT,
+                    'name' => 'class',
+                    'short_description' => 'BarBar',
+                ],
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'hello',
+                    'snippet' => 'hello()',
+                ],
+            ]
+        ];
 
         yield 'shows static member on instance method' => [
             <<<'EOT'
@@ -553,18 +608,19 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 $bar-><>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'goodbye',
-                'snippet' => 'goodbye()',
-            ],
-            [
-                'type' => Suggestion::TYPE_METHOD,
-                'name' => 'hello',
-                'snippet' => 'hello()',
-            ],
-        ]];
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'goodbye',
+                    'snippet' => 'goodbye()',
+                ],
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'hello',
+                    'snippet' => 'hello()',
+                ],
+            ]
+        ];
 
         yield 'static property' => [
             <<<'EOT'
@@ -578,13 +634,14 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                 BarBar::$f<>
 
                 EOT
-        , [
-            [
-                'type' => Suggestion::TYPE_PROPERTY,
-                'name' => '$foo',
-                'short_description' => 'pub static $foo: Foo',
-            ],
-        ]];
+            , [
+                [
+                    'type' => Suggestion::TYPE_PROPERTY,
+                    'name' => '$foo',
+                    'short_description' => 'pub static $foo: Foo',
+                ],
+            ]
+        ];
     }
 
     /**

--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseClassMemberCompletorTest.php
@@ -307,6 +307,32 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
             ]
         ];
 
+        yield 'Partially completed method with text after' => [
+            <<<'EOT'
+                <?php
+
+                class Foobar
+                {
+                    public function aaa()
+                    {
+                        $this->bb<>new Foobar();
+                    }
+
+                    public function bbb() {}
+                    public function ccc() {}
+                }
+
+                EOT
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'bbb',
+                    'short_description' => 'pub bbb()',
+                    'snippet' => 'bbb()',
+                ]
+            ]
+        ];
+
         yield 'Partially completed static method with brackets' => [
             <<<'EOT'
                 <?php
@@ -329,6 +355,32 @@ class WorseClassMemberCompletorTest extends TolerantCompletorTestCase
                     'name' => 'bbb',
                     'short_description' => 'pub bbb()',
                     'snippet' => 'bbb',
+                ]
+            ]
+        ];
+
+        yield 'Partially completed static method with text after' => [
+            <<<'EOT'
+                <?php
+
+                class Foobar
+                {
+                    public function aaa()
+                    {
+                        self::bb<>new Foobar();
+                    }
+
+                    public static function bbb() {}
+                    public static function ccc() {}
+                }
+
+                EOT
+            , [
+                [
+                    'type' => Suggestion::TYPE_METHOD,
+                    'name' => 'bbb',
+                    'short_description' => 'pub bbb()',
+                    'snippet' => 'bbb()',
                 ]
             ]
         ];


### PR DESCRIPTION
Changed it so it just looks at the character after the byte offset if it is a `(`. Added a test so that case `$this->my<>new SomeClass` will complete the whole signature.