### PR TITLE
WorseNamedParameterCompletor: ignored when completing a variable

### DIFF
--- a/lib/Bridge/TolerantParser/WorseReflection/WorseNamedParameterCompletor.php
+++ b/lib/Bridge/TolerantParser/WorseReflection/WorseNamedParameterCompletor.php
@@ -10,6 +10,7 @@ use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\Expression\MemberAccessExpression;
 use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 use Microsoft\PhpParser\Node\Expression\ScopedPropertyAccessExpression;
+use Microsoft\PhpParser\Node\Expression\Variable;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Phpactor\Completion\Bridge\TolerantParser\TolerantCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\Helper\NodeQuery;
@@ -55,6 +56,10 @@ class WorseNamedParameterCompletor implements TolerantCompletor
                 ArgumentExpressionList::class
             ]
         )) {
+            return true;
+        }
+
+        if ($node instanceof Variable) {
             return true;
         }
 

--- a/lib/Core/DocumentPrioritizer/SimilarityResultPrioritizer.php
+++ b/lib/Core/DocumentPrioritizer/SimilarityResultPrioritizer.php
@@ -32,6 +32,6 @@ class SimilarityResultPrioritizer implements DocumentPrioritizer
 
         $range = Suggestion::PRIORITY_LOW - Suggestion::PRIORITY_MEDIUM;
 
-        return Suggestion::PRIORITY_MEDIUM + $range - $range * $similarity;
+        return (int) (Suggestion::PRIORITY_MEDIUM + $range - $range * $similarity);
     }
 }

--- a/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseNamedParameterCompletorTest.php
+++ b/tests/Integration/Bridge/TolerantParser/WorseReflection/WorseNamedParameterCompletorTest.php
@@ -49,6 +49,12 @@ class WorseNamedParameterCompletorTest extends TolerantCompletorTestCase
             ]
         ];
 
+        yield 'Ignore when completing a variable' => [
+            '<?php class A{function bee(string $one){}} $a = new A(); $a->bee($o<>',
+            [
+            ]
+        ];
+
         yield 'Method call in partial method call' => [
             '<?php class B {function boo(): B{}}' .
             'class A{function bee(string $one){}} $b=new B();$a=new A(); $a->bee($b->boo()-><>',


### PR DESCRIPTION
I often find myself in the situation where a function/method's parameter
name match the name of a local variable I want to provide as argument.

In this situation the completion results include the named parameter
which can be annoying depending on the sort done by the client side.

![image](https://user-images.githubusercontent.com/11501572/133935220-6ef179f6-f386-40a2-876d-25e96bfd5fb2.png)


I think it's sane to not include named parameters when we already
started to type a variable name, our little `$` in php will finally pay
off :)